### PR TITLE
feat(entity): add identity-hashing EntityMap/EntitySet and migrate semantic analysis maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,9 @@ version = "0.1.0"
 [[package]]
 name = "jcc_interner"
 version = "0.1.0"
+dependencies = [
+ "jcc_entity",
+]
 
 [[package]]
 name = "termcolor"

--- a/crates/jcc/src/lower.rs
+++ b/crates/jcc/src/lower.rs
@@ -14,9 +14,7 @@ use jcc_backend::{
     },
     Ident, IdentInterner,
 };
-use jcc_entity::SecondaryMap;
-
-use std::collections::HashMap;
+use jcc_entity::{EntityMap, SecondaryMap};
 
 pub struct LoweringPass<'ctx> {
     // The SSA builder
@@ -26,7 +24,7 @@ pub struct LoweringPass<'ctx> {
     /// The semantic analysis context
     sema: &'ctx SemaCtx<'ctx>,
     /// Blocks tracked for statements
-    tracked: HashMap<ast::Stmt, TrackedBlock>,
+    tracked: EntityMap<ast::Stmt, TrackedBlock>,
     /// Mapping from semantic symbols to SSA symbols
     symbols: SecondaryMap<sema::Symbol, Option<SymbolEntry>>,
 }
@@ -40,7 +38,7 @@ impl<'ctx> LoweringPass<'ctx> {
         Self {
             ast,
             sema,
-            tracked: HashMap::new(),
+            tracked: EntityMap::default(),
             builder: Builder::new(interner),
             symbols: SecondaryMap::with_capacity(sema.symbols.len()),
         }
@@ -960,14 +958,12 @@ impl<'ctx> LoweringPass<'ctx> {
     }
 
     fn get_or_make_labeled(&mut self, stmt: ast::Stmt, name: Ident, span: Span) -> Block {
-        let entry = self
-            .tracked
-            .entry(stmt)
-            .or_insert_with(|| TrackedBlock::Label(self.builder.build_block_sym(name, span)));
-        match entry {
-            TrackedBlock::Label(l) => *l,
-            _ => panic!("expected a labeled block"),
+        if let Some(TrackedBlock::Label(l)) = self.tracked.get(&stmt) {
+            return *l;
         }
+        let block = self.builder.build_block_sym(name, span);
+        self.tracked.insert(stmt, TrackedBlock::Label(block));
+        block
     }
 
     fn get_or_make_function(

--- a/crates/jcc/src/sema/control.rs
+++ b/crates/jcc/src/sema/control.rs
@@ -7,8 +7,9 @@ use jcc_backend::{
     codemap::{file::FileId, span::Span, Diagnostic, Label},
     Ident,
 };
+use jcc_entity::EntityMap;
 
-use std::{cell::Cell, collections::HashMap};
+use std::{cell::Cell, collections::hash_map::Entry};
 
 // ---------------------------------------------------------------------------
 // ControlPass
@@ -24,7 +25,7 @@ pub struct ControlPass<'a, 'ctx> {
     /// The stack of currently tracked statements
     tracked_stmts: Vec<TrackedStmt>,
     /// The currently tracked labels
-    tracked_labels: HashMap<Ident, TrackedLabel<'a>>,
+    tracked_labels: EntityMap<Ident, TrackedLabel<'a>>,
 }
 
 impl<'a, 'ctx> ControlPass<'a, 'ctx> {
@@ -34,7 +35,7 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
             ctx,
             tracked_stmts: Vec::new(),
             result: ControlResult::default(),
-            tracked_labels: HashMap::default(),
+            tracked_labels: EntityMap::default(),
         }
     }
 
@@ -117,7 +118,7 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                 let entry = self
                     .tracked_labels
                     .entry(*label)
-                    .or_insert(TrackedLabel::Unresolved(vec![(target, data.span)]));
+                    .or_insert_with(|| TrackedLabel::Unresolved(vec![(target, data.span)]));
                 if let TrackedLabel::Resolved(stmt) = entry {
                     target.set(Some(*stmt));
                 }
@@ -155,8 +156,7 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                     Some(switch_stmt) => self
                         .ctx
                         .switches
-                        .entry(*switch_stmt)
-                        .or_default()
+                        .get_or_insert_default(*switch_stmt)
                         .cases
                         .push(stmt),
                     _ => self.result.diagnostics.push(ControlDiagnostic {
@@ -173,7 +173,7 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                     _ => None,
                 }) {
                     Some(switch_stmt) => {
-                        let switch = self.ctx.switches.entry(*switch_stmt).or_default();
+                        let switch = self.ctx.switches.get_or_insert_default(*switch_stmt);
                         match switch.default {
                             None => switch.default = Some(stmt),
                             Some(_) => self.result.diagnostics.push(ControlDiagnostic {
@@ -192,24 +192,26 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                 self.visit_stmt(*inner);
             }
             StmtKind::Label { label, stmt: inner } => {
-                let entry = self
-                    .tracked_labels
-                    .entry(*label)
-                    .or_insert(TrackedLabel::Resolved(stmt));
-                match entry {
-                    TrackedLabel::Unresolved(v) => {
-                        v.iter().for_each(|(target, _)| {
-                            target.set(Some(stmt));
-                        });
-                        *entry = TrackedLabel::Resolved(stmt);
+                match self.tracked_labels.entry(*label) {
+                    Entry::Vacant(e) => {
+                        e.insert(TrackedLabel::Resolved(stmt));
                     }
-                    TrackedLabel::Resolved(s) => {
-                        if stmt != *s {
-                            self.result.diagnostics.push(ControlDiagnostic {
-                                span: data.span,
-                                file: self.ast.file,
-                                kind: ControlDiagnosticKind::RedeclaredLabel,
-                            });
+                    Entry::Occupied(mut e) => {
+                        let e = e.get_mut();
+                        match e {
+                            TrackedLabel::Unresolved(v) => {
+                                v.iter().for_each(|(target, _)| target.set(Some(stmt)));
+                                *e = TrackedLabel::Resolved(stmt);
+                            }
+                            TrackedLabel::Resolved(s) => {
+                                if stmt != *s {
+                                    self.result.diagnostics.push(ControlDiagnostic {
+                                        span: data.span,
+                                        file: self.ast.file,
+                                        kind: ControlDiagnosticKind::RedeclaredLabel,
+                                    });
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/jcc/src/sema/mod.rs
+++ b/crates/jcc/src/sema/mod.rs
@@ -8,9 +8,7 @@ use crate::ast::{
     Stmt,
 };
 
-use jcc_entity::{entity_impl, SecondaryMap};
-
-use std::collections::HashMap;
+use jcc_entity::{entity_impl, EntityMap, SecondaryMap};
 
 // ---------------------------------------------------------------------------
 // SemaCtx
@@ -22,7 +20,7 @@ entity_impl!(Symbol, "symbol");
 
 pub struct SemaCtx<'ctx> {
     pub ty: &'ctx TyCtx<'ctx>,
-    pub switches: HashMap<Stmt, SwitchCases>,
+    pub switches: EntityMap<Stmt, SwitchCases>,
     pub symbols: SecondaryMap<Symbol, Option<SymbolInfo<'ctx>>>,
 }
 
@@ -30,7 +28,7 @@ impl<'ctx> SemaCtx<'ctx> {
     pub fn new(ty: &'ctx TyCtx<'ctx>, capacity: usize) -> Self {
         Self {
             ty,
-            switches: HashMap::new(),
+            switches: EntityMap::default(),
             symbols: SecondaryMap::with_capacity(capacity),
         }
     }

--- a/crates/jcc/src/sema/resolve.rs
+++ b/crates/jcc/src/sema/resolve.rs
@@ -8,12 +8,10 @@ use crate::{
 
 use jcc_backend::{
     codemap::{file::FileId, span::Span, Diagnostic, Label},
-    interner::symtab::SymbolTable,
+    interner::symtab::EntitySymbolTable,
     Ident,
 };
-use jcc_entity::EntityRef;
-
-use std::collections::HashMap;
+use jcc_entity::{EntityMap, EntityRef};
 
 // ---------------------------------------------------------------------------
 // ResolverPass
@@ -26,10 +24,10 @@ pub struct ResolverPass<'a, 'ctx> {
     result: ResolverResult,
     /// The current symbol count
     symbol_count: usize,
-    /// The current scope symbol table
-    scope: SymbolTable<Ident, SymbolInfo>,
     /// The global symbols map
-    globals: HashMap<Ident, sema::Symbol>,
+    globals: EntityMap<Ident, sema::Symbol>,
+    /// The current scope symbol table
+    scope: EntitySymbolTable<Ident, SymbolInfo>,
 }
 
 impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
@@ -37,9 +35,9 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
         Self {
             ast,
             symbol_count: 1,
-            globals: HashMap::new(),
-            scope: SymbolTable::new(),
+            globals: EntityMap::default(),
             result: ResolverResult::default(),
+            scope: EntitySymbolTable::default(),
         }
     }
 
@@ -248,7 +246,7 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
 
     #[inline]
     fn get_or_create_global_symbol(&mut self, name: &Symbol) -> sema::Symbol {
-        let symbol = self.globals.entry(name.name).or_insert_with(|| {
+        let symbol = self.globals.get_or_insert_with(name.name, || {
             let symbol = sema::Symbol::new(self.symbol_count);
             self.symbol_count += 1;
             symbol

--- a/crates/jcc_backend/Cargo.toml
+++ b/crates/jcc_backend/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 
 [dependencies]
 jcc_entity = { path = "../jcc_entity" }
-jcc_interner = { path = "../jcc_interner" }
 jcc_codemap = { path = "../jcc_codemap", features = ["color"] }
+jcc_interner = { path = "../jcc_interner", features = ["entity"] }

--- a/crates/jcc_backend/src/ir/mod.rs
+++ b/crates/jcc_backend/src/ir/mod.rs
@@ -6,7 +6,7 @@ pub mod term;
 pub mod ty;
 
 use jcc_codemap::span::Span;
-use jcc_entity::{entity_impl, PrimaryMap, SparseSet};
+use jcc_entity::{entity_impl, EntitySet, PrimaryMap};
 
 use crate::{
     ir::{
@@ -120,7 +120,7 @@ impl FunctionData {
         BlocksPreIter {
             prog,
             stack,
-            seen: SparseSet::new(),
+            seen: EntitySet::new(),
         }
     }
 
@@ -135,7 +135,7 @@ impl FunctionData {
         BlocksPostIter {
             prog,
             stack,
-            seen: SparseSet::new(),
+            seen: EntitySet::new(),
         }
     }
 }
@@ -143,7 +143,7 @@ impl FunctionData {
 pub struct BlocksPreIter<'a> {
     prog: &'a Program,
     stack: Vec<Block>,
-    seen: SparseSet<Block>,
+    seen: EntitySet<Block>,
 }
 
 impl Iterator for BlocksPreIter<'_> {
@@ -164,7 +164,7 @@ impl Iterator for BlocksPreIter<'_> {
 
 pub struct BlocksPostIter<'a> {
     prog: &'a Program,
-    seen: SparseSet<Block>,
+    seen: EntitySet<Block>,
     stack: Vec<(Block, bool)>,
 }
 

--- a/crates/jcc_entity/src/hash.rs
+++ b/crates/jcc_entity/src/hash.rs
@@ -1,0 +1,277 @@
+//! Identity-hashing collections for entity-keyed maps and sets.
+
+use crate::EntityRef;
+
+use std::{
+    collections::{hash_map, hash_set, HashMap, HashSet},
+    hash::{BuildHasherDefault, Hasher},
+};
+
+/// A pass-through hasher that uses integer values directly as hash codes.
+///
+/// This eliminates hashing overhead for types whose [`Hash`] implementation
+/// reduces to a single integer write (e.g., `u32` newtypes like entity references).
+/// Collision resistance is preserved as long as each key maps to a distinct integer.
+#[derive(Default, Debug, Clone)]
+pub struct EntityHasher(u64);
+
+impl Hasher for EntityHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.0 = u64::from(i);
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    fn write(&mut self, _: &[u8]) {
+        panic!("EntityHasher only supports integer writes");
+    }
+}
+
+/// A [`HashSet`] keyed by [`EntityRef`] types using identity hashing.
+///
+/// Hashing is a no-op: the key's integer index is used directly as the hash code.
+pub struct EntitySet<K: EntityRef>(HashSet<K, BuildHasherDefault<EntityHasher>>);
+
+impl<K: EntityRef> EntitySet<K> {
+    /// Creates a new empty set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of elements.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the set contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Removes all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns `true` if the set contains `key`.
+    #[inline]
+    pub fn contains(&self, key: &K) -> bool {
+        self.0.contains(key)
+    }
+
+    /// Inserts `key`. Returns `true` if it was not already present.
+    #[inline]
+    pub fn insert(&mut self, key: K) -> bool {
+        self.0.insert(key)
+    }
+
+    /// Removes `key`. Returns `true` if it was present.
+    #[inline]
+    pub fn remove(&mut self, key: &K) -> bool {
+        self.0.remove(key)
+    }
+
+    /// Returns an iterator over the elements.
+    #[inline]
+    pub fn iter(&self) -> hash_set::Iter<'_, K> {
+        self.0.iter()
+    }
+}
+
+impl<K: EntityRef> Default for EntitySet<K> {
+    fn default() -> Self {
+        EntitySet(HashSet::default())
+    }
+}
+
+impl<K: EntityRef + Clone> Clone for EntitySet<K> {
+    fn clone(&self) -> Self {
+        EntitySet(self.0.clone())
+    }
+}
+
+impl<K: EntityRef + std::fmt::Debug> std::fmt::Debug for EntitySet<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<K: EntityRef> IntoIterator for EntitySet<K> {
+    type Item = K;
+    type IntoIter = hash_set::IntoIter<K>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, K: EntityRef> IntoIterator for &'a EntitySet<K> {
+    type Item = &'a K;
+    type IntoIter = hash_set::Iter<'a, K>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+/// A [`HashMap`] keyed by [`EntityRef`] types using identity hashing.
+///
+/// Hashing is a no-op: the key's integer index is used directly as the hash code.
+pub struct EntityMap<K: EntityRef, V>(HashMap<K, V, BuildHasherDefault<EntityHasher>>);
+
+impl<K: EntityRef, V> EntityMap<K, V> {
+    /// Creates a new empty map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of entries.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the map contains no entries.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Removes all entries.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns a reference to the value for `key`, or `None` if absent.
+    #[inline]
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.0.get(key)
+    }
+
+    /// Returns a mutable reference to the value for `key`, or `None` if absent.
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.0.get_mut(key)
+    }
+
+    /// Returns `true` if the map contains an entry for `key`.
+    #[inline]
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.0.contains_key(key)
+    }
+
+    /// Inserts a key-value pair, returning the previous value if the key was present.
+    #[inline]
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.0.insert(key, value)
+    }
+
+    /// Removes and returns the value for `key`, or `None` if absent.
+    #[inline]
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.0.remove(key)
+    }
+
+    /// Gets the entry for `key` for in-place manipulation.
+    #[inline]
+    pub fn entry(&mut self, key: K) -> hash_map::Entry<'_, K, V> {
+        self.0.entry(key)
+    }
+
+    /// Returns a mutable reference to the value for `key`, inserting `f()` if absent.
+    #[inline]
+    pub fn get_or_insert_with(&mut self, key: K, f: impl FnOnce() -> V) -> &mut V {
+        self.0.entry(key).or_insert_with(f)
+    }
+
+    /// Returns an iterator over `(&key, &value)` pairs.
+    #[inline]
+    pub fn iter(&self) -> hash_map::Iter<'_, K, V> {
+        self.0.iter()
+    }
+
+    /// Returns an iterator over `(&key, &mut value)` pairs.
+    #[inline]
+    pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, K, V> {
+        self.0.iter_mut()
+    }
+
+    /// Returns an iterator over keys.
+    #[inline]
+    pub fn keys(&self) -> hash_map::Keys<'_, K, V> {
+        self.0.keys()
+    }
+
+    /// Returns an iterator over values.
+    #[inline]
+    pub fn values(&self) -> hash_map::Values<'_, K, V> {
+        self.0.values()
+    }
+
+    /// Returns a mutable iterator over values.
+    #[inline]
+    pub fn values_mut(&mut self) -> hash_map::ValuesMut<'_, K, V> {
+        self.0.values_mut()
+    }
+}
+
+impl<K: EntityRef, V: Default> EntityMap<K, V> {
+    /// Returns a mutable reference to the value for `key`, inserting a default value if absent.
+    #[inline]
+    pub fn get_or_insert_default(&mut self, key: K) -> &mut V {
+        self.0.entry(key).or_default()
+    }
+}
+
+impl<K: EntityRef, V> Default for EntityMap<K, V> {
+    fn default() -> Self {
+        EntityMap(HashMap::default())
+    }
+}
+
+impl<K: EntityRef + Clone, V: Clone> Clone for EntityMap<K, V> {
+    fn clone(&self) -> Self {
+        EntityMap(self.0.clone())
+    }
+}
+
+impl<K: EntityRef + std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for EntityMap<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<K: EntityRef, V> IntoIterator for EntityMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = hash_map::IntoIter<K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, K: EntityRef, V> IntoIterator for &'a EntityMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = hash_map::Iter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, K: EntityRef, V> IntoIterator for &'a mut EntityMap<K, V> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = hash_map::IterMut<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}

--- a/crates/jcc_entity/src/hash.rs
+++ b/crates/jcc_entity/src/hash.rs
@@ -31,6 +31,7 @@ impl Hasher for EntityHasher {
         self.0 = i;
     }
 
+    #[allow(clippy::panic)]
     fn write(&mut self, _: &[u8]) {
         panic!("EntityHasher only supports integer writes");
     }

--- a/crates/jcc_entity/src/lib.rs
+++ b/crates/jcc_entity/src/lib.rs
@@ -5,18 +5,20 @@
 //! IR where you have multiple interrelated entity types (instructions, blocks,
 //! functions, etc.) that should not be confused.
 
+mod hash;
 mod primary;
 mod secondary;
 mod slice;
 mod sparse;
 
+pub use hash::{EntityHasher, EntityMap, EntitySet};
 pub use primary::PrimaryMap;
 pub use secondary::SecondaryMap;
 pub use slice::{EntitySlice, SlicePool};
 pub use sparse::{map::SparseMap, set::SparseSet};
 
 /// Trait for types that can be used as entity references.
-pub trait EntityRef: Copy + Eq {
+pub trait EntityRef: Copy + Eq + std::hash::Hash {
     /// Create a new entity reference
     fn new(index: usize) -> Self;
     /// Get the index of the entity to index the array

--- a/crates/jcc_interner/Cargo.toml
+++ b/crates/jcc_interner/Cargo.toml
@@ -9,6 +9,12 @@ license = "MIT"
 repository = "https://github.com/jsilll/jcc"
 readme = "README.md"
 
+[features]
+entity = ["dep:jcc_entity"]
+
+[dependencies]
+jcc_entity = { path = "../jcc_entity", optional = true }
+
 [lints.rust]
 missing_docs = "warn"
 unreachable_pub = "warn"

--- a/crates/jcc_interner/src/lib.rs
+++ b/crates/jcc_interner/src/lib.rs
@@ -162,7 +162,7 @@ impl<M> Interner<M> {
     /// Panics if the `Symbol` is invalid or out of bounds.
     #[inline]
     pub fn lookup(&self, id: Symbol<M>) -> &str {
-        self.vec[id.0 as usize]
+        self.vec[id.index_impl()]
     }
 
     /// Retrieves the string associated with the given `Symbol`, if it exists.
@@ -176,7 +176,7 @@ impl<M> Interner<M> {
     /// `Some(&str)` if the `Symbol` is valid, or `None` if it is invalid or out of bounds.
     #[inline]
     pub fn get(&self, id: Symbol<M>) -> Option<&str> {
-        self.vec.get(id.0 as usize).copied()
+        self.vec.get(id.index_impl()).copied()
     }
 
     /// Interns the given string and returns its associated `Symbol`.

--- a/crates/jcc_interner/src/lib.rs
+++ b/crates/jcc_interner/src/lib.rs
@@ -16,13 +16,13 @@
 
 pub mod symtab;
 
-use std::{collections::HashMap, marker::PhantomData, num::NonZeroU32};
+use std::{collections::HashMap, marker::PhantomData};
 
 /// A lightweight handle representing an interned string.
 ///
 /// `Symbol` is a small, copyable type that acts as a unique identifier.
 /// It is parameterized by `M` to ensure strict type safety between different interners.
-pub struct Symbol<M>(NonZeroU32, PhantomData<M>);
+pub struct Symbol<M>(u32, PhantomData<M>);
 
 impl<M> Copy for Symbol<M> {}
 impl<M> Clone for Symbol<M> {
@@ -47,6 +47,33 @@ impl<M> std::hash::Hash for Symbol<M> {
 impl<M> std::fmt::Debug for Symbol<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Symbol").field(&self.0).finish()
+    }
+}
+
+impl<M> Symbol<M> {
+    #[inline]
+    fn new_impl(index: usize) -> Self {
+        debug_assert!(index < u32::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
+        Symbol(index as u32, PhantomData)
+    }
+
+    #[inline]
+    fn index_impl(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[cfg(feature = "entity")]
+impl<M> jcc_entity::EntityRef for Symbol<M> {
+    #[inline]
+    fn new(index: usize) -> Self {
+        Self::new_impl(index)
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        self.index_impl()
     }
 }
 
@@ -135,7 +162,7 @@ impl<M> Interner<M> {
     /// Panics if the `Symbol` is invalid or out of bounds.
     #[inline]
     pub fn lookup(&self, id: Symbol<M>) -> &str {
-        self.vec[id.0.get() as usize - 1]
+        self.vec[id.0 as usize]
     }
 
     /// Retrieves the string associated with the given `Symbol`, if it exists.
@@ -149,7 +176,7 @@ impl<M> Interner<M> {
     /// `Some(&str)` if the `Symbol` is valid, or `None` if it is invalid or out of bounds.
     #[inline]
     pub fn get(&self, id: Symbol<M>) -> Option<&str> {
-        self.vec.get(id.0.get() as usize - 1).copied()
+        self.vec.get(id.0 as usize).copied()
     }
 
     /// Interns the given string and returns its associated `Symbol`.
@@ -169,14 +196,7 @@ impl<M> Interner<M> {
         if let Some(&id) = self.map.get(name) {
             return id;
         }
-        // Safety: We explicitly ensure that the NonZeroU32 is never zero by
-        // starting the count from 1 and incrementing for each new string.
-        let symbol = unsafe {
-            Symbol(
-                NonZeroU32::new_unchecked(u32::try_from(self.vec.len() + 1).unwrap_or(u32::MAX)),
-                PhantomData,
-            )
-        };
+        let symbol = Symbol::new_impl(self.vec.len());
         // Safety: The allocated string reference is valid as long as the interner is alive.
         let name = unsafe { self.alloc(name) };
         self.map.insert(name, symbol);

--- a/crates/jcc_interner/src/symtab.rs
+++ b/crates/jcc_interner/src/symtab.rs
@@ -15,9 +15,17 @@
 //!   backwards, restoring the previous values of modified keys.
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
-    hash::Hash,
+    collections::{
+        hash_map::{Entry, RandomState},
+        HashMap,
+    },
+    hash::{BuildHasher, Hash},
 };
+
+#[cfg(feature = "entity")]
+/// A [`SymbolTable`] using identity hashing for [`jcc_entity::EntityRef`] keys.
+pub type EntitySymbolTable<S, V> =
+    SymbolTable<S, V, std::hash::BuildHasherDefault<jcc_entity::EntityHasher>>;
 
 /// Holds the value and the version at which it was last modified.
 #[derive(Debug, Clone)]
@@ -41,37 +49,48 @@ enum LogEntry<S, V> {
 /// It supports scoped symbol management, allowing for nested scopes.
 ///
 /// This implementation is optimized to avoid memory allocations when pushing and popping scopes.
-/// It uses a pair of `HashMap` for fast lookups and an "undo log" to efficiently
-/// revert changes when a scope ends. This version uses a versioning system to ensure
-/// that a symbol's previous value is only logged once per scope.
+/// It uses a `HashMap` for fast lookups and an "undo log" to efficiently revert changes when a
+/// scope ends. A versioning system ensures that a symbol's previous value is only logged once per scope.
+///
+/// The hash builder `H` can be customized to control the backing hashing strategy. It defaults to
+/// the standard [`RandomState`].
 ///
 /// # Type Parameters
 /// - `S`: The type of the symbol keys. Must implement `Eq`, `Hash`, and `Clone`.
 /// - `V`: The type of the values associated with the symbols. Must implement `Clone`.
+/// - `H`: The hash builder. Defaults to [`RandomState`].
 #[derive(Debug, Clone)]
-pub struct SymbolTable<S, V> {
+pub struct SymbolTable<S, V, H = RandomState> {
     /// The current version of the scope stack, used to track changes.
     version: u32,
     /// A log of changes made in each scope, used for efficient popping.
     log: Vec<LogEntry<S, V>>,
     /// The single table containing the current state of all scoped symbols.
-    scoped: HashMap<S, ScopedValue<V>>,
+    scoped: HashMap<S, ScopedValue<V>, H>,
 }
 
-impl<S, V> Default for SymbolTable<S, V> {
+impl<S, V, H: BuildHasher + Default> Default for SymbolTable<S, V, H> {
     fn default() -> Self {
-        Self::new()
+        Self::with_hasher(H::default())
     }
 }
 
 impl<S, V> SymbolTable<S, V> {
-    /// Creates a new, empty `SymbolTable`.
+    /// Creates a new, empty `SymbolTable` with the default [`RandomState`] hasher.
     #[inline]
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<S, V, H> SymbolTable<S, V, H> {
+    /// Creates a new, empty `SymbolTable` with the given hash builder.
+    #[inline]
+    pub fn with_hasher(hasher: H) -> Self {
         SymbolTable {
             version: 0,
-            scoped: HashMap::new(),
             log: Vec::with_capacity(64),
+            scoped: HashMap::with_hasher(hasher),
         }
     }
 
@@ -90,10 +109,11 @@ impl<S, V> SymbolTable<S, V> {
     }
 }
 
-impl<S, V> SymbolTable<S, V>
+impl<S, V, H> SymbolTable<S, V, H>
 where
     S: Clone + Eq + Hash,
     V: Clone,
+    H: BuildHasher,
 {
     /// Retrieves a reference to the value associated with the given key.
     #[inline]
@@ -142,8 +162,6 @@ where
     }
 
     /// Inserts a key-value pair into the current scope or the global table.
-    /// If there are active scopes, the pair is inserted into the most recent one.
-    /// Otherwise, it is inserted into the global table.
     ///
     /// Returns `None` if the key was newly inserted in the current scope, or the previous value if it was updated.
     pub fn insert(&mut self, key: S, value: V) -> Option<V> {
@@ -178,17 +196,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new_and_default() {
-        let table: SymbolTable<String, i32> = SymbolTable::new();
-        assert!(table.scoped.is_empty());
-        assert!(table.log.is_empty());
-
-        let table: SymbolTable<String, i32> = SymbolTable::default();
-        assert!(table.scoped.is_empty());
-        assert!(table.log.is_empty());
-    }
-
-    #[test]
     fn test_shadowing() {
         let mut table = SymbolTable::new();
         table.insert("x".to_string(), 10);
@@ -211,47 +218,47 @@ mod tests {
     #[test]
     fn test_multiple_updates_single_history_entry() {
         let mut table = SymbolTable::new();
-        table.insert("x".to_string(), 1);
+        table.insert("x", 1);
 
         table.push_scope();
         assert_eq!(table.log.len(), 2);
 
-        table.insert("x".to_string(), 10);
-        assert_eq!(table.get(&"x".to_string()), Some(&10));
+        table.insert("x", 10);
+        assert_eq!(table.get(&"x"), Some(&10));
         assert_eq!(table.log.len(), 3);
 
-        table.insert("x".to_string(), 20);
-        assert_eq!(table.get(&"x".to_string()), Some(&20));
+        table.insert("x", 20);
+        assert_eq!(table.get(&"x"), Some(&20));
         assert_eq!(table.log.len(), 3);
 
-        table.insert("x".to_string(), 30);
-        assert_eq!(table.get(&"x".to_string()), Some(&30));
+        table.insert("x", 30);
+        assert_eq!(table.get(&"x"), Some(&30));
         assert_eq!(table.log.len(), 3);
 
-        table.insert("y".to_string(), 99);
-        assert_eq!(table.get(&"y".to_string()), Some(&99));
+        table.insert("y", 99);
+        assert_eq!(table.get(&"y"), Some(&99));
         assert_eq!(table.log.len(), 4);
 
         table.pop_scope();
-        assert_eq!(table.get(&"x".to_string()), Some(&1));
-        assert_eq!(table.get(&"y".to_string()), None);
+        assert_eq!(table.get(&"x"), Some(&1));
+        assert_eq!(table.get(&"y"), None);
     }
 
     #[test]
     fn test_clear_scope() {
         let mut table = SymbolTable::new();
 
-        table.insert("g".to_string(), 0);
+        table.insert("g", 0);
         table.push_scope();
-        table.insert("s1".to_string(), 1);
-        table.insert("s2".to_string(), 2);
+        table.insert("s1", 1);
+        table.insert("s2", 2);
         table.clear_scope();
 
-        assert_eq!(table.get(&"s1".to_string()), None);
-        assert_eq!(table.get(&"s2".to_string()), None);
-        assert_eq!(table.get(&"g".to_string()), Some(&0));
+        assert_eq!(table.get(&"s1"), None);
+        assert_eq!(table.get(&"s2"), None);
+        assert_eq!(table.get(&"g"), Some(&0));
 
         table.pop_scope();
-        assert_eq!(table.get(&"g".to_string()), Some(&0));
+        assert_eq!(table.get(&"g"), Some(&0));
     }
 }


### PR DESCRIPTION


## Summary

Introduces `EntitySet<K>` and `EntityMap<K, V>` in `jcc_entity`. These are `HashSet` and `HashMap` wrappers
that use identity hashing for `EntityRef`-keyed maps. Because entity references are `u32` newtypes,
hashing is a no-op: the integer value is used directly as the hash code.

Migrates the four `HashMap` instances in the semantic analysis and lowering passes to use these new
types. Also simplifies `Symbol<M>` from `NonZeroU32` to plain `u32` and
makes `jcc_entity` an optional dependency of `jcc_interner` behind an `entity` feature flag.
