### PR TITLE
feat(prep): replace gcc -E with a native streaming preprocessor

### DIFF
--- a/crates/jcc/src/ast/parse.rs
+++ b/crates/jcc/src/ast/parse.rs
@@ -5,7 +5,8 @@ use crate::{
         ExprData, ExprKind, ExprSlice, ForInit, Stmt, StmtData, StmtKind, StorageClass, Symbol,
         UnaryOp,
     },
-    token::{lex::LexerIssue, stream::TokenStream, Token, TokenKind},
+    prep::{stream::PrepStream, PrepIssue},
+    token::{Token, TokenKind},
 };
 
 use jcc_backend::{
@@ -28,20 +29,20 @@ pub struct Parser<'a, 'ctx> {
     file: &'a SourceFile,
     /// The type context used for creating and interning types.
     tys: &'ctx TyCtx<'ctx>,
-    /// The lexer that provides a stream of tokens.
-    lexer: TokenStream<'a>,
     /// The interner for identifier interning.
     interner: &'a mut IdentInterner,
-    /// A temporary buffer for collecting type specifiers.
-    specifiers: Vec<TokenKind>,
-    /// The result of the parsing process, containing the AST and diagnostics.
-    result: ParserResult<'ctx>,
+    /// Preprocessor stream with two-token lookahead.
+    stream: PrepStream<'a>,
     /// A stack used for building expression lists, like function arguments.
     expr_stack: Vec<Expr>,
     /// A stack used for building declaration lists, like function parameters.
     decl_stack: Vec<Decl>,
     /// A stack used for building block item lists, like function bodies.
-    items_stack: Vec<BlockItem>,
+    item_stack: Vec<BlockItem>,
+    /// A scratch buffer for collecting type specifiers.
+    specifiers: Vec<TokenKind>,
+    /// The result of the parsing process, containing the AST and diagnostics.
+    result: ParserResult<'ctx>,
 }
 
 impl<'a, 'ctx> Parser<'a, 'ctx> {
@@ -54,11 +55,11 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
             tys,
             file,
             interner,
-            lexer: TokenStream::new(file),
+            stream: PrepStream::new(file),
             specifiers: Vec::with_capacity(16),
             expr_stack: Vec::with_capacity(16),
             decl_stack: Vec::with_capacity(16),
-            items_stack: Vec::with_capacity(16),
+            item_stack: Vec::with_capacity(16),
             result: ParserResult::new(file.id()),
         }
     }
@@ -99,7 +100,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     fn parse_type(&mut self, span: Span) -> Ty<'ctx> {
         match self.specifiers.as_slice() {
             [] => {
-                self.result.parser_diagnostics.push(Issue::new(
+                self.result.parser_issues.push(Issue::new(
                     ParserIssue::MissingTypeSpecifier,
                     self.file.id(),
                     span,
@@ -115,7 +116,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 self.tys.double_ty
             }
             specs if specs.contains(&TokenKind::KwDouble) || specs.contains(&TokenKind::KwVoid) => {
-                self.result.parser_diagnostics.push(Issue::new(
+                self.result.parser_issues.push(Issue::new(
                     ParserIssue::InvalidTypeSpecifier,
                     self.file.id(),
                     span,
@@ -138,14 +139,14 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                         | TokenKind::KwLong
                         | TokenKind::KwSigned
                         | TokenKind::KwUnsigned => {
-                            self.result.parser_diagnostics.push(Issue::new(
+                            self.result.parser_issues.push(Issue::new(
                                 ParserIssue::DuplicateTypeSpecifier,
                                 self.file.id(),
                                 span,
                             ));
                         }
                         _ => {
-                            self.result.parser_diagnostics.push(Issue::new(
+                            self.result.parser_issues.push(Issue::new(
                                 ParserIssue::InvalidTypeSpecifier,
                                 self.file.id(),
                                 span,
@@ -154,7 +155,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                     }
                 }
                 if has_signed && has_unsigned {
-                    self.result.parser_diagnostics.push(Issue::new(
+                    self.result.parser_issues.push(Issue::new(
                         ParserIssue::ConflictingTypeSpecifiers,
                         self.file.id(),
                         span,
@@ -203,7 +204,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
 
         let span = start_span.merge(end_span);
         if count > 1 {
-            self.result.parser_diagnostics.push(Issue::new(
+            self.result.parser_issues.push(Issue::new(
                 ParserIssue::MultipleStorageClasses,
                 self.file.id(),
                 span,
@@ -297,7 +298,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 }))
             }
             _ => {
-                self.result.parser_diagnostics.push(Issue::new(
+                self.result.parser_issues.push(Issue::new(
                     ParserIssue::ExpectedToken(TokenKind::Semi),
                     self.file.id(),
                     token.span,
@@ -356,21 +357,21 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     }
 
     fn parse_body(&mut self) -> Block {
-        let base = self.items_stack.len();
+        let base = self.item_stack.len();
         while let Some(Token { kind, .. }) = self.peek() {
             match kind {
                 TokenKind::RBrace => break,
                 kind if kind.is_decl_start() => match self.parse_decl() {
                     None => self.sync(TokenKind::Semi, TokenKind::RBrace),
-                    Some(decl) => self.items_stack.push(BlockItem::Decl(decl)),
+                    Some(decl) => self.item_stack.push(BlockItem::Decl(decl)),
                 },
                 _ => match self.parse_stmt() {
                     None => self.sync(TokenKind::Semi, TokenKind::RBrace),
-                    Some(expr) => self.items_stack.push(BlockItem::Stmt(expr)),
+                    Some(expr) => self.item_stack.push(BlockItem::Stmt(expr)),
                 },
             }
         }
-        self.result.ast.items.extend(self.items_stack.drain(base..))
+        self.result.ast.items.extend(self.item_stack.drain(base..))
     }
 
     fn parse_stmt(&mut self) -> Option<Stmt> {
@@ -535,17 +536,13 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 }))
             }
             TokenKind::Identifier => {
-                let is_label = {
-                    let mut ahead = self.lexer.clone();
-                    ahead.next();
-                    matches!(
-                        ahead.next(),
-                        Some(Ok(Token {
-                            kind: TokenKind::Colon,
-                            ..
-                        }))
-                    )
-                };
+                let is_label = matches!(
+                    self.peek2(),
+                    Some(Token {
+                        kind: TokenKind::Colon,
+                        ..
+                    })
+                );
                 if is_label {
                     let (span, label) = self.eat_identifier()?;
                     self.eat(TokenKind::Colon)?;
@@ -775,7 +772,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 }
             }
             _ => {
-                self.result.parser_diagnostics.push(Issue::new(
+                self.result.parser_issues.push(Issue::new(
                     ParserIssue::UnexpectedToken,
                     self.file.id(),
                     span,
@@ -854,12 +851,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     #[inline]
     fn next(&mut self) -> Option<Token> {
         loop {
-            match self.lexer.next() {
-                None => return None,
-                Some(Ok(token)) => return Some(token),
-                Some(Err(diag)) => {
-                    self.result.lexer_diagnostics.push(diag);
-                }
+            match self.stream.next()? {
+                Ok(token) => return Some(token),
+                Err(issue) => self.result.prep_issues.push(issue),
             }
         }
     }
@@ -867,13 +861,23 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     #[inline]
     fn peek(&mut self) -> Option<Token> {
         loop {
-            match self.lexer.peek() {
-                None => return None,
-                Some(Ok(token)) => return Some(*token),
-                Some(Err(diag)) => {
-                    self.result.lexer_diagnostics.push(diag.clone());
-                    self.lexer.next();
+            match self.stream.peek()? {
+                Ok(token) => return Some(*token),
+                Err(issue) => {
+                    self.result.prep_issues.push(issue.clone());
+                    self.stream.next();
                 }
+            }
+        }
+    }
+
+    #[inline]
+    fn peek2(&mut self) -> Option<Token> {
+        match self.stream.peek2()? {
+            Ok(token) => Some(*token),
+            Err(issue) => {
+                self.result.prep_issues.push(issue.clone());
+                None
             }
         }
     }
@@ -894,7 +898,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
 
     #[inline]
     fn peek_span(&mut self) -> Span {
-        self.peek().map(|t| t.span).unwrap_or_default()
+        self.peek().map(|t| t.span).unwrap()
     }
 
     #[inline]
@@ -902,7 +906,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
         if let Some(token) = self.peek() {
             Some(token)
         } else {
-            self.result.parser_diagnostics.push(Issue::new(
+            self.result.parser_issues.push(Issue::new(
                 ParserIssue::UnexpectedEof,
                 self.file.id(),
                 Span::single(self.file.end_pos()),
@@ -916,7 +920,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
         if token.kind == kind {
             self.next()
         } else {
-            self.result.parser_diagnostics.push(Issue::new(
+            self.result.parser_issues.push(Issue::new(
                 ParserIssue::ExpectedToken(kind),
                 self.file.id(),
                 token.span,
@@ -928,7 +932,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     #[inline]
     fn eat_some(&mut self) -> Option<Token> {
         self.next().or_else(|| {
-            self.result.parser_diagnostics.push(Issue::new(
+            self.result.parser_issues.push(Issue::new(
                 ParserIssue::UnexpectedEof,
                 self.file.id(),
                 Span::single(self.file.end_pos()),
@@ -947,7 +951,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 Some((span, symbol))
             }
             _ => {
-                self.result.parser_diagnostics.push(Issue::new(
+                self.result.parser_issues.push(Issue::new(
                     ParserIssue::ExpectedToken(TokenKind::Identifier),
                     self.file.id(),
                     token.span,
@@ -1084,16 +1088,16 @@ impl From<TokenKind> for Option<Precedence> {
 
 pub struct ParserResult<'ctx> {
     pub ast: Ast<'ctx>,
-    pub lexer_diagnostics: Vec<Issue<LexerIssue>>,
-    pub parser_diagnostics: Vec<Issue<ParserIssue>>,
+    pub prep_issues: Vec<Issue<PrepIssue>>,
+    pub parser_issues: Vec<Issue<ParserIssue>>,
 }
 
 impl ParserResult<'_> {
     pub fn new(file: FileId) -> Self {
         Self {
             ast: Ast::new(file),
-            lexer_diagnostics: Vec::new(),
-            parser_diagnostics: Vec::new(),
+            prep_issues: Vec::new(),
+            parser_issues: Vec::new(),
         }
     }
 }

--- a/crates/jcc/src/cli.rs
+++ b/crates/jcc/src/cli.rs
@@ -132,40 +132,21 @@ impl CompileOptions {
 
 impl CompileOptions {
     pub fn run(&self, profiler: &mut Profiler) -> Result<()> {
-        let pp_path = self.path.with_extension("i");
-
-        profiler.time("Preprocessor (gcc -E)", || {
-            let out = std::process::Command::new("gcc")
-                .args(["-E", "-P"])
-                .arg(&self.path)
-                .arg("-o")
-                .arg(&pp_path)
-                .output()
-                .context("failed to invoke gcc -E")?;
-            if !out.status.success() {
-                if self.emit_options.diagnostics {
-                    eprintln!("{}", String::from_utf8_lossy(&out.stderr));
-                }
-                return Err(anyhow::anyhow!("exiting due to preprocessor errors"));
-            }
-            Ok(())
-        })?;
-
         let mut files = SimpleFiles::new();
-        let fid = files
-            .add_file(&pp_path)
-            .context("failed to read preprocessed file")?;
-        let file = files.get(fid).context("internal: file not in db")?;
+        let file = files
+            .add_file(&self.path)
+            .context("failed to read source file")?;
+        let file = files.get(file).context("internal: file not in db")?;
 
-        // Lexing and parsing
+        // Lexing, preprocessing, and parsing
         let tys = TyCtx::new();
         let mut interner = IdentInterner::new();
         let r = profiler.time("Parser", || Parser::new(file, &tys, &mut interner).parse());
-        check_pass(self, &mut files, "lexer", &r.lexer_diagnostics)?;
+        check_pass(self, &mut files, "preprocessor", &r.prep_issues)?;
         if self.stop_after == Some(Stage::Lex) {
             return Ok(());
         }
-        check_pass(self, &mut files, "parser", &r.parser_diagnostics)?;
+        check_pass(self, &mut files, "parser", &r.parser_issues)?;
         if r.ast.root.is_empty() {
             return Err(anyhow::anyhow!("exiting due to empty parse tree"));
         }

--- a/crates/jcc/src/lib.rs
+++ b/crates/jcc/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ast;
 pub mod cli;
 pub mod desugar;
 pub mod lower;
+pub mod prep;
 pub mod profile;
 pub mod sema;
 pub mod token;

--- a/crates/jcc/src/prep/mod.rs
+++ b/crates/jcc/src/prep/mod.rs
@@ -1,0 +1,263 @@
+mod stack;
+mod table;
+
+pub mod stream;
+
+use crate::token::{lex::LexerIssue, stream::TokenStream, Token, TokenKind};
+use stack::{CondStack, CondState};
+use table::MacroTable;
+
+use jcc_backend::codemap::{
+    file::SourceFile, span::Span, Diagnostic, IntoDiagnostic, Issue, Label,
+};
+
+use std::iter::FusedIterator;
+
+// ---------------------------------------------------------------------------
+// Preprocessor
+// ---------------------------------------------------------------------------
+
+pub struct Preprocessor<'a> {
+    file: &'a SourceFile,
+    stack: CondStack,
+    current: Vec<Token>,
+    pending: Vec<Token>,
+    macros: MacroTable<'a>,
+    stream: TokenStream<'a>,
+}
+
+impl<'a> Preprocessor<'a> {
+    pub fn new(file: &'a SourceFile) -> Self {
+        Self {
+            file,
+            current: Vec::new(),
+            pending: Vec::new(),
+            stack: CondStack::new(),
+            macros: MacroTable::new(),
+            stream: TokenStream::new(file),
+        }
+    }
+
+    fn try_expand(&mut self, span: Span) -> bool {
+        let Some(tokens) = self
+            .file
+            .slice(span)
+            .and_then(|name| self.macros.expansion(name))
+        else {
+            return false;
+        };
+        self.pending.extend(tokens.iter().rev().copied());
+        true
+    }
+
+    fn eval_cond(&mut self) -> bool {
+        let res = self
+            .stream
+            .next_on_line()
+            .and_then(Result::ok)
+            .filter(|t| t.kind == TokenKind::NumInt)
+            .and_then(|t| self.file.slice(t.span))
+            .and_then(|s| s.parse::<i64>().ok())
+            .is_some_and(|n| n != 0);
+        self.stream.skip_line();
+        res
+    }
+
+    fn read_ident_inline(&mut self, span: Span) -> Result<Option<&'a str>, Issue<PrepIssue>> {
+        match self.stream.next_on_line() {
+            Some(Err(e)) => Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
+            None => Err(Issue::new(
+                PrepIssue::ExpectedMacroName,
+                self.file.id(),
+                span,
+            )),
+            Some(Ok(token)) => match token.kind {
+                TokenKind::Identifier => Ok(self.file.slice(token.span)),
+                _ => Err(Issue::new(
+                    PrepIssue::ExpectedMacroName,
+                    self.file.id(),
+                    token.span,
+                )),
+            },
+        }
+    }
+
+    fn process_directive(&mut self) -> Result<(), Issue<PrepIssue>> {
+        let span = match self.stream.next_on_line() {
+            None => return Ok(()),
+            Some(Ok(token)) => token.span,
+            Some(Err(e)) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
+        };
+        let Some(keyword) = self.file.slice(span) else {
+            return Ok(());
+        };
+        match keyword {
+            "pragma" => self.stream.skip_line(),
+            "if" => {
+                if self.stack.is_suppressed() {
+                    self.stream.skip_line();
+                    self.stack.push(CondState::Done);
+                } else {
+                    let active = self.eval_cond();
+                    self.stack.push(active);
+                }
+            }
+            "ifdef" | "ifndef" => {
+                if self.stack.is_suppressed() {
+                    self.stream.skip_line();
+                    self.stack.push(CondState::Done);
+                } else {
+                    let Some(name) = self.read_ident_inline(span)? else {
+                        return Ok(());
+                    };
+                    self.stream.skip_line();
+                    let defined = self.macros.is_defined(name);
+                    self.stack.push(if keyword == "ifdef" {
+                        defined
+                    } else {
+                        !defined
+                    });
+                }
+            }
+            "endif" => {
+                self.stream.skip_line();
+                if !self.stack.pop() {
+                    return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span));
+                }
+            }
+            "else" => {
+                self.stream.skip_line();
+                match self.stack.top() {
+                    Some(CondState::False) => self.stack.set(CondState::True),
+                    Some(_) => self.stack.set(CondState::Done),
+                    None => {
+                        return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span))
+                    }
+                }
+            }
+            "elif" => match self.stack.top() {
+                Some(CondState::Done) => self.stream.skip_line(),
+                Some(CondState::False) => {
+                    let active = self.eval_cond();
+                    self.stack.set(active);
+                }
+                Some(CondState::True) => {
+                    self.stream.skip_line();
+                    self.stack.set(CondState::Done);
+                }
+                None => {
+                    self.stream.skip_line();
+                    return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span));
+                }
+            },
+            _ if self.stack.is_suppressed() => self.stream.skip_line(),
+            "include" => {
+                self.stream.skip_line();
+                return Err(Issue::new(
+                    PrepIssue::IncludeNotSupported,
+                    self.file.id(),
+                    span,
+                ));
+            }
+            "undef" => {
+                let Some(name) = self.read_ident_inline(span)? else {
+                    return Ok(());
+                };
+                self.stream.skip_line();
+                self.macros.undefine(name);
+            }
+            "define" => {
+                let Some(name) = self.read_ident_inline(span)? else {
+                    return Ok(());
+                };
+                while let Some(item) = self.stream.next_on_line() {
+                    match item {
+                        Ok(token) => self.current.push(token),
+                        Err(e) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
+                    }
+                }
+                self.macros.define(name, self.current.drain(..));
+            }
+            _ => {
+                self.stream.skip_line();
+                return Err(Issue::new(
+                    PrepIssue::UnknownDirective,
+                    self.file.id(),
+                    span,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> FusedIterator for Preprocessor<'a> {}
+impl<'a> Iterator for Preprocessor<'a> {
+    type Item = Result<Token, Issue<PrepIssue>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.pending.pop() {
+                Some(token) => {
+                    if !self.try_expand(token.span) {
+                        return Some(Ok(token));
+                    }
+                }
+                None => match self.stream.next()? {
+                    Err(issue) => {
+                        return Some(Err(Issue::new(
+                            PrepIssue::Lexer(issue.kind),
+                            issue.file,
+                            issue.span,
+                        )));
+                    }
+                    Ok(token) => match token.kind {
+                        TokenKind::CommentBlock | TokenKind::CommentInline => continue,
+                        TokenKind::DirectiveHash => {
+                            if let Err(e) = self.process_directive() {
+                                return Some(Err(e));
+                            }
+                        }
+                        _ => {
+                            if !self.stack.is_suppressed() && !self.try_expand(token.span) {
+                                return Some(Ok(token));
+                            }
+                        }
+                    },
+                },
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PrepIssue
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub enum PrepIssue {
+    MissingEndif,
+    UnmatchedEndif,
+    UnknownDirective,
+    ExpectedMacroName,
+    IncludeNotSupported,
+    Lexer(LexerIssue),
+}
+
+impl IntoDiagnostic for PrepIssue {
+    fn into_diagnostic(self, file: jcc_backend::codemap::file::FileId, span: Span) -> Diagnostic {
+        let (msg1, msg2, note) = match self {
+            PrepIssue::Lexer(issue) => return issue.into_diagnostic(file, span),
+            PrepIssue::UnmatchedEndif => ("unmatched `#endif` or `#else`", "no matching `#if`", None),
+            PrepIssue::IncludeNotSupported => ("`#include` is not yet implemented", "`#include` is not supported", None),
+            PrepIssue::ExpectedMacroName => ("expected an identifier after preprocessor directive", "expected a macro name here", None),
+            PrepIssue::MissingEndif => ("unterminated `#if` block", "opened here", Some("every `#if`/`#ifdef`/`#ifndef` must be closed by `#endif`")),
+            PrepIssue::UnknownDirective => ("unknown preprocessor directive", "unknown directive", Some("supported directives: #if, #ifdef, #ifndef, #elif, #else, #endif, #define, #undef, #pragma")),
+        };
+        Diagnostic::error()
+            .with_notes(note)
+            .with_message(msg1)
+            .with_label(Label::primary(file, span).with_message(msg2))
+    }
+}

--- a/crates/jcc/src/prep/stack.rs
+++ b/crates/jcc/src/prep/stack.rs
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------
+// CondStack
+// ---------------------------------------------------------------------------
+
+pub struct CondStack {
+    stack: Vec<CondState>,
+    suppressed_depth: usize,
+}
+
+impl CondStack {
+    pub fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            suppressed_depth: 0,
+        }
+    }
+
+    /// Returns `true` if any level of the stack is currently suppressing output.
+    pub fn is_suppressed(&self) -> bool {
+        self.suppressed_depth > 0
+    }
+
+    /// Returns the state of the innermost open block without consuming it.
+    pub fn top(&self) -> Option<CondState> {
+        self.stack.last().copied()
+    }
+
+    /// Opens a new conditional level with the given state.
+    pub fn push(&mut self, state: impl Into<CondState>) {
+        let state = state.into();
+        if state != CondState::True {
+            self.suppressed_depth += 1;
+        }
+        self.stack.push(state);
+    }
+
+    /// Closes the innermost conditional level. Returns `false` if the stack was already empty.
+    pub fn pop(&mut self) -> bool {
+        if let Some(state) = self.stack.pop() {
+            if state != CondState::True {
+                self.suppressed_depth -= 1;
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Transitions the innermost level to `state`, updating suppression depth as needed.
+    ///
+    /// Note: This is a no-op if the stack is empty.
+    pub fn set(&mut self, state: impl Into<CondState>) {
+        let state = state.into();
+        if let Some(last) = self.stack.last_mut() {
+            let was = *last != CondState::True;
+            let will = state != CondState::True;
+            match (was, will) {
+                (true, false) => self.suppressed_depth -= 1,
+                (false, true) => self.suppressed_depth += 1,
+                _ => {}
+            }
+            *last = state;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CondState
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CondState {
+    /// Branch has not yet been taken.
+    False,
+    /// Branch is active, tokens are emitted.
+    True,
+    /// A prior branch was already taken, all remaining branches are suppressed.
+    Done,
+}
+
+impl From<bool> for CondState {
+    fn from(active: bool) -> Self {
+        if active {
+            CondState::True
+        } else {
+            CondState::False
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_not_suppressed() {
+        let s = CondStack::new();
+        assert!(!s.is_suppressed());
+    }
+
+    #[test]
+    fn pop_on_empty_returns_false() {
+        let mut s = CondStack::new();
+        assert!(!s.pop());
+    }
+
+    #[test]
+    fn push_false_suppresses() {
+        let mut s = CondStack::new();
+        s.push(CondState::False);
+        assert!(s.is_suppressed());
+    }
+
+    #[test]
+    fn push_done_suppresses() {
+        let mut s = CondStack::new();
+        s.push(CondState::Done);
+        assert!(s.is_suppressed());
+    }
+
+    #[test]
+    fn push_true_does_not_suppress() {
+        let mut s = CondStack::new();
+        s.push(CondState::True);
+        assert!(!s.is_suppressed());
+    }
+
+    #[test]
+    fn push_pop_round_trip() {
+        let mut s = CondStack::new();
+        s.push(CondState::False);
+        assert!(s.is_suppressed());
+        assert!(s.pop());
+        assert!(!s.is_suppressed());
+    }
+
+    #[test]
+    fn set_on_empty_is_noop() {
+        let mut s = CondStack::new();
+        s.set(CondState::True);
+        assert!(!s.is_suppressed());
+    }
+
+    #[test]
+    fn set_lifts_suppression() {
+        let mut s = CondStack::new();
+        s.push(CondState::False);
+        s.set(CondState::True);
+        assert!(!s.is_suppressed());
+        assert_eq!(s.top(), Some(CondState::True));
+    }
+
+    #[test]
+    fn set_adds_suppression() {
+        let mut s = CondStack::new();
+        s.push(CondState::True);
+        s.set(CondState::Done);
+        assert!(s.is_suppressed());
+        assert_eq!(s.top(), Some(CondState::Done));
+    }
+
+    #[test]
+    fn set_done_to_done_noop() {
+        let mut s = CondStack::new();
+        s.push(CondState::Done);
+        s.set(CondState::Done);
+        assert!(s.is_suppressed());
+        assert_eq!(s.top(), Some(CondState::Done));
+    }
+
+    #[test]
+    fn set_false_to_false_noop() {
+        let mut s = CondStack::new();
+        s.push(CondState::False);
+        s.set(CondState::False);
+        assert!(s.is_suppressed());
+        assert_eq!(s.top(), Some(CondState::False));
+    }
+
+    #[test]
+    fn nested_outer_true_inner_false() {
+        let mut s = CondStack::new();
+        s.push(CondState::True);
+        s.push(CondState::False);
+        assert!(s.is_suppressed());
+    }
+
+    #[test]
+    fn nested_suppression_survives_pop() {
+        let mut s = CondStack::new();
+        s.push(CondState::False);
+        s.push(CondState::True);
+        assert!(s.is_suppressed());
+        s.pop();
+        assert!(s.is_suppressed());
+    }
+
+    #[test]
+    fn suppressed_depth_tracks_levels() {
+        let mut s = CondStack::new();
+
+        s.push(CondState::False);
+        s.push(CondState::False);
+        s.push(CondState::False);
+        assert!(s.is_suppressed());
+
+        s.pop();
+        assert!(s.is_suppressed());
+
+        s.pop();
+        assert!(s.is_suppressed());
+
+        s.pop();
+        assert!(!s.is_suppressed());
+    }
+}

--- a/crates/jcc/src/prep/stream.rs
+++ b/crates/jcc/src/prep/stream.rs
@@ -1,0 +1,100 @@
+use crate::prep::Preprocessor;
+
+use jcc_backend::codemap::file::SourceFile;
+
+use std::iter::{FusedIterator, Peekable};
+
+// ---------------------------------------------------------------------------
+// PrepStream
+// ---------------------------------------------------------------------------
+
+pub type PrepItem<'a> = <Preprocessor<'a> as Iterator>::Item;
+
+pub struct PrepStream<'a> {
+    lookahead: Option<PrepItem<'a>>,
+    inner: Peekable<Preprocessor<'a>>,
+}
+
+impl<'a> FusedIterator for PrepStream<'a> {}
+impl<'a> Iterator for PrepStream<'a> {
+    type Item = PrepItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lookahead.take().or_else(|| self.inner.next())
+    }
+}
+
+impl<'a> PrepStream<'a> {
+    /// Creates a new `PrepStream` from the given source file.
+    pub fn new(file: &'a SourceFile) -> Self {
+        Self {
+            lookahead: None,
+            inner: Preprocessor::new(file).peekable(),
+        }
+    }
+
+    /// Returns the next token without consuming it.
+    pub fn peek(&mut self) -> Option<&PrepItem<'a>> {
+        if self.lookahead.is_none() {
+            self.lookahead = self.inner.next();
+        }
+        self.lookahead.as_ref()
+    }
+
+    /// Returns the second token without consuming either token.
+    ///
+    /// Returns `None` if fewer than two tokens remain.
+    pub fn peek2(&mut self) -> Option<&PrepItem<'a>> {
+        self.peek()?;
+        self.inner.peek()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::TokenKind;
+    use jcc_backend::codemap::file::{FileId, SourceFile};
+
+    fn file(src: &str) -> SourceFile {
+        SourceFile::from_source(FileId::new(0), "<test>", format!("{src}\n"))
+    }
+
+    #[test]
+    fn peek_does_not_consume() {
+        let f = file("int return");
+        let mut s = PrepStream::new(&f);
+
+        let peek = s.peek().and_then(|r| r.as_ref().ok()).map(|t| t.kind);
+        assert_eq!(peek, Some(TokenKind::KwInt));
+
+        let next = s.next().and_then(|r| r.ok()).map(|t| t.kind);
+        assert_eq!(next, Some(TokenKind::KwInt));
+    }
+
+    #[test]
+    fn peek2_returns_none() {
+        let f = file("int");
+        let mut s = PrepStream::new(&f);
+
+        assert!(s.peek2().is_none());
+
+        let next = s.next().and_then(|r| r.ok()).map(|t| t.kind);
+        assert_eq!(next, Some(TokenKind::KwInt));
+    }
+
+    #[test]
+    fn peek2_returns_second_token() {
+        let f = file("int return");
+        let mut s = PrepStream::new(&f);
+
+        let second = s.peek2().and_then(|r| r.as_ref().ok()).map(|t| t.kind);
+        assert_eq!(second, Some(TokenKind::KwReturn));
+
+        let first = s.next().and_then(|r| r.ok()).map(|t| t.kind);
+        assert_eq!(first, Some(TokenKind::KwInt));
+
+        let second = s.next().and_then(|r| r.ok()).map(|t| t.kind);
+        assert_eq!(second, Some(TokenKind::KwReturn));
+    }
+}

--- a/crates/jcc/src/prep/table.rs
+++ b/crates/jcc/src/prep/table.rs
@@ -1,0 +1,129 @@
+use crate::token::Token;
+
+use std::{collections::HashMap, ops::Range};
+
+// ---------------------------------------------------------------------------
+// MacroTable
+// ---------------------------------------------------------------------------
+
+pub struct MacroTable<'a> {
+    arena: Vec<Token>,
+    map: HashMap<&'a str, Range<u32>>,
+}
+
+impl<'a> MacroTable<'a> {
+    /// Creates an empty macro table.
+    pub fn new() -> Self {
+        Self {
+            arena: Vec::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    /// Removes a macro definition.
+    ///
+    /// Note: The body tokens remain in the pool but are no longer reachable.
+    pub fn undefine(&mut self, name: &str) {
+        self.map.remove(name);
+    }
+
+    /// Returns `true` if `name` is currently defined.
+    pub fn is_defined(&self, name: &str) -> bool {
+        self.map.contains_key(name)
+    }
+
+    /// Returns the body tokens for `name`, or `None` if not defined.
+    pub fn expansion(&self, name: &str) -> Option<&[Token]> {
+        self.map
+            .get(name)
+            .map(|r| &self.arena[r.start as usize..r.end as usize])
+    }
+
+    /// Defines (or redefines) a macro.
+    ///
+    /// Note: Any previous body for the same name is orphaned but not freed.
+    pub fn define(&mut self, name: &'a str, body: impl IntoIterator<Item = Token>) {
+        let start = self.arena.len() as u32;
+        self.arena.extend(body);
+        let end = self.arena.len() as u32;
+        self.map.insert(name, start..end);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::TokenKind;
+    use jcc_backend::codemap::span::Span;
+
+    const BODY: [Token; 1] = [Token {
+        span: Span::DEFAULT,
+        kind: TokenKind::NumInt,
+    }];
+
+    const NEW_BODY: [Token; 2] = [
+        Token {
+            span: Span::DEFAULT,
+            kind: TokenKind::NumFloat,
+        },
+        Token {
+            span: Span::DEFAULT,
+            kind: TokenKind::NumFloat,
+        },
+    ];
+
+    #[test]
+    fn undefine_noop() {
+        let mut t = MacroTable::new();
+        t.undefine("MISSING");
+    }
+
+    #[test]
+    fn undefine_removes_macro() {
+        let mut t = MacroTable::new();
+        t.define("X", BODY);
+
+        t.undefine("X");
+        assert!(!t.is_defined("X"));
+        assert!(t.expansion("X").is_none());
+    }
+
+    #[test]
+    fn undefined_macro_returns_none() {
+        let t = MacroTable::new();
+        assert!(!t.is_defined("FOO"));
+        assert!(t.expansion("FOO").is_none());
+    }
+
+    #[test]
+    fn define_empty() {
+        let mut t = MacroTable::new();
+        t.define("EMPTY", []);
+        assert!(t.is_defined("EMPTY"));
+        assert_eq!(t.expansion("EMPTY"), Some([].as_slice()));
+    }
+
+    #[test]
+    fn define_and_expand() {
+        let mut t = MacroTable::new();
+        t.define("X", BODY);
+        assert_eq!(t.expansion("X"), Some(BODY.as_slice()));
+    }
+
+    #[test]
+    fn redefine_replaces_expansion() {
+        let mut t = MacroTable::new();
+        t.define("X", BODY);
+        t.define("X", NEW_BODY);
+        assert_eq!(t.expansion("X"), Some(NEW_BODY.as_slice()));
+    }
+
+    #[test]
+    fn multiple_macros_are_independent() {
+        let mut t = MacroTable::new();
+        t.define("A", BODY);
+        t.define("B", NEW_BODY);
+        assert_eq!(t.expansion("A"), Some(BODY.as_slice()));
+        assert_eq!(t.expansion("B"), Some(NEW_BODY.as_slice()));
+    }
+}

--- a/crates/jcc/src/token/lex.rs
+++ b/crates/jcc/src/token/lex.rs
@@ -7,7 +7,10 @@ use jcc_backend::codemap::{
     Diagnostic, IntoDiagnostic, Issue, Label,
 };
 
-use std::{iter::Peekable, str::CharIndices};
+use std::{
+    iter::{FusedIterator, Peekable},
+    str::CharIndices,
+};
 
 // ---------------------------------------------------------------------------
 // Lexer
@@ -21,6 +24,7 @@ pub struct Lexer<'a> {
     chars: Peekable<CharIndices<'a>>,
 }
 
+impl<'a> FusedIterator for Lexer<'a> {}
 impl<'a> Iterator for Lexer<'a> {
     type Item = Result<Token, Issue<LexerIssue>>;
 
@@ -33,7 +37,7 @@ impl<'a> Iterator for Lexer<'a> {
             let idx = self.chars.next()?.0;
             if self.line_start {
                 self.pos = BytePos::from(idx);
-                return Some(Ok(self.token(TokenKind::NewLine, 1)));
+                return Some(Ok(Token::new(TokenKind::NewLine, self.span(1))));
             }
         }
         let can_emit_hash = self.line_start;
@@ -43,7 +47,7 @@ impl<'a> Iterator for Lexer<'a> {
         Some(match c {
             c if c.is_ascii_digit() => self.number(false),
             c if c.is_ascii_alphabetic() || c == '_' => Ok(self.word()),
-            '#' if can_emit_hash => Ok(self.token(TokenKind::DirectiveHash, 1)),
+            '#' if can_emit_hash => Ok(Token::new(TokenKind::DirectiveHash, self.span(1))),
             '.' => match self.chars.peek() {
                 Some((_, c)) if c.is_ascii_digit() => self.number(true),
                 _ => Err(Issue::new(
@@ -52,17 +56,17 @@ impl<'a> Iterator for Lexer<'a> {
                     Span::single(self.pos),
                 )),
             },
-            ';' => Ok(self.token(TokenKind::Semi, 1)),
-            ',' => Ok(self.token(TokenKind::Comma, 1)),
-            ':' => Ok(self.token(TokenKind::Colon, 1)),
-            '~' => Ok(self.token(TokenKind::Tilde, 1)),
-            '(' => Ok(self.token(TokenKind::LParen, 1)),
-            '{' => Ok(self.token(TokenKind::LBrace, 1)),
-            '[' => Ok(self.token(TokenKind::LBrack, 1)),
-            ')' => Ok(self.token(TokenKind::RParen, 1)),
-            '}' => Ok(self.token(TokenKind::RBrace, 1)),
-            ']' => Ok(self.token(TokenKind::RBrack, 1)),
-            '?' => Ok(self.token(TokenKind::Question, 1)),
+            ';' => Ok(Token::new(TokenKind::Semi, self.span(1))),
+            ',' => Ok(Token::new(TokenKind::Comma, self.span(1))),
+            ':' => Ok(Token::new(TokenKind::Colon, self.span(1))),
+            '~' => Ok(Token::new(TokenKind::Tilde, self.span(1))),
+            '(' => Ok(Token::new(TokenKind::LParen, self.span(1))),
+            '{' => Ok(Token::new(TokenKind::LBrace, self.span(1))),
+            '[' => Ok(Token::new(TokenKind::LBrack, self.span(1))),
+            ')' => Ok(Token::new(TokenKind::RParen, self.span(1))),
+            '}' => Ok(Token::new(TokenKind::RBrace, self.span(1))),
+            ']' => Ok(Token::new(TokenKind::RBrack, self.span(1))),
+            '?' => Ok(Token::new(TokenKind::Question, self.span(1))),
             '=' => Ok(self.match1('=', TokenKind::EqEq, TokenKind::Eq)),
             '!' => Ok(self.match1('=', TokenKind::BangEq, TokenKind::Bang)),
             '*' => Ok(self.match1('=', TokenKind::StarEq, TokenKind::Star)),
@@ -125,11 +129,8 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline]
-    fn token(&mut self, kind: TokenKind, len: u32) -> Token {
-        Token {
-            kind,
-            span: Span::new(self.pos, self.pos + len).unwrap_or_default(),
-        }
+    fn span(&self, len: u32) -> Span {
+        Span::new(self.pos, self.pos + len).unwrap()
     }
 
     #[inline]
@@ -137,9 +138,9 @@ impl<'a> Lexer<'a> {
         match self.chars.peek() {
             Some((_, ch2)) if *ch2 == ch => {
                 self.chars.next();
-                self.token(kind, 2)
+                Token::new(kind, self.span(2))
             }
-            _ => self.token(fallback, 1),
+            _ => Token::new(fallback, self.span(1)),
         }
     }
 
@@ -161,7 +162,7 @@ impl<'a> Lexer<'a> {
             }
             _ => (fallback, 1),
         };
-        self.token(kind, len)
+        Token::new(kind, self.span(len))
     }
 
     #[inline]
@@ -175,13 +176,13 @@ impl<'a> Lexer<'a> {
         match self.chars.peek() {
             Some((_, c)) if *c == kind1.0 => {
                 self.chars.next();
-                self.token(kind1.1, 2)
+                Token::new(kind1.1, self.span(2))
             }
             Some((_, c)) if *c == kind2.0 => {
                 self.chars.next();
                 self.match1(kind3.0, kind3.1, kind2.1)
             }
-            _ => self.token(fallback, 1),
+            _ => Token::new(fallback, self.span(1)),
         }
     }
 
@@ -197,10 +198,7 @@ impl<'a> Lexer<'a> {
             .peek()
             .map(|(idx, _)| *idx as u32)
             .unwrap_or(self.file.source().len() as u32);
-        Token {
-            kind: TokenKind::CommentInline,
-            span: Span::new(self.pos, end).unwrap_or_default(),
-        }
+        Token::new(TokenKind::CommentInline, Span::new(self.pos, end).unwrap())
     }
 
     fn comment_block(&mut self) -> Result<Token, Issue<LexerIssue>> {
@@ -218,7 +216,7 @@ impl<'a> Lexer<'a> {
             .peek()
             .map(|(idx, _)| *idx as u32)
             .unwrap_or(self.file.source().len() as u32);
-        let span = Span::new(self.pos, end).unwrap_or_default();
+        let span = Span::new(self.pos, end).unwrap();
         if closed {
             Ok(Token {
                 span,
@@ -264,7 +262,7 @@ impl<'a> Lexer<'a> {
                     return Err(Issue::new(
                         LexerIssue::EmptyExponent,
                         self.file.id(),
-                        Span::new(self.pos, end).unwrap_or_default(),
+                        Span::new(self.pos, end).unwrap(),
                     ));
                 }
             }
@@ -306,7 +304,7 @@ impl<'a> Lexer<'a> {
                     return Err(Issue::new(
                         LexerIssue::InvalidNumberSuffix,
                         self.file.id(),
-                        Span::new(self.pos, end).unwrap_or_default(),
+                        Span::new(self.pos, end).unwrap(),
                     ));
                 }
                 end
@@ -315,7 +313,7 @@ impl<'a> Lexer<'a> {
 
         Ok(Token {
             kind,
-            span: Span::new(self.pos, end).unwrap_or_default(),
+            span: Span::new(self.pos, end).unwrap(),
         })
     }
 
@@ -327,7 +325,7 @@ impl<'a> Lexer<'a> {
             .get(self.pos.to_usize()..end.to_usize())
             .unwrap_or_default();
         Token {
-            span: Span::new(self.pos, end).unwrap_or_default(),
+            span: Span::new(self.pos, end).unwrap(),
             kind: TokenKind::from_keyword(ident).unwrap_or(TokenKind::Identifier),
         }
     }

--- a/crates/jcc/src/token/mod.rs
+++ b/crates/jcc/src/token/mod.rs
@@ -13,6 +13,12 @@ pub struct Token {
     pub kind: TokenKind,
 }
 
+impl Token {
+    pub fn new(kind: TokenKind, span: Span) -> Self {
+        Self { kind, span }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TokenKind
 // ---------------------------------------------------------------------------

--- a/crates/jcc/src/token/stream.rs
+++ b/crates/jcc/src/token/stream.rs
@@ -2,7 +2,7 @@ use jcc_backend::codemap::file::SourceFile;
 
 use crate::token::{lex::Lexer, TokenKind};
 
-use std::iter::Peekable;
+use std::iter::{FusedIterator, Peekable};
 
 // ---------------------------------------------------------------------------
 // TokenStream
@@ -29,6 +29,7 @@ impl<'a> From<Lexer<'a>> for TokenStream<'a> {
     }
 }
 
+impl<'a> FusedIterator for TokenStream<'a> {}
 impl<'a> Iterator for TokenStream<'a> {
     type Item = <Lexer<'a> as Iterator>::Item;
 

--- a/crates/jcc_codemap/src/span.rs
+++ b/crates/jcc_codemap/src/span.rs
@@ -32,13 +32,19 @@ use crate::byte::BytePos;
 /// Spans are half-open ranges [start, end) of byte positions.
 /// They are cheap to copy and should be used liberally throughout
 /// your AST and IR structures.
-#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Span {
     start: BytePos,
     end: BytePos,
 }
 
 impl Span {
+    /// A default span representing no source code location.
+    pub const DEFAULT: Self = Self {
+        start: BytePos(0),
+        end: BytePos(0),
+    };
+
     /// Creates a new span from a start and end position.
     ///
     /// Returns None if start > end.
@@ -251,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_default_span() {
-        let span = Span::default();
+        let span = Span::DEFAULT;
         assert!(span.is_empty());
         assert_eq!(span.start(), BytePos(0));
         assert_eq!(span.end(), BytePos(0));


### PR DESCRIPTION
# feat(prep): replace gcc -E with a native streaming preprocessor

Replaces the external `gcc -E` subprocess used for C preprocessing with a
native, streaming Rust implementation (`PrepStream`). The preprocessor now
runs inline with the lexer/parser pipeline instead of writing a temporary
file and spawning a child process per source file.

## Benchmark results

Suite: `tests/tests` · 428 files compiled · release build

### Before (gcc -E)

| Pass                  |   n  |     Total |    Mean |     Min |     Max |     p95 |
|-----------------------|-----:|----------:|--------:|--------:|--------:|--------:|
| Preprocessor (gcc -E) | 428  | 3079.606ms | 7.195ms | 5.520ms | 28.669ms | 8.844ms |
| Parser                | 428  |    5.863ms | 0.013ms | 0.005ms |  0.113ms | 0.025ms |
| Resolver              | 428  |    0.922ms | 0.002ms | 0.000ms |  0.017ms | 0.004ms |
| Control               | 428  |    0.344ms | 0.000ms | 0.000ms |  0.003ms | 0.001ms |
| Typer                 | 428  |    0.786ms | 0.001ms | 0.000ms |  0.014ms | 0.003ms |
| Desugar               | 428  |    0.062ms | 0.000ms | 0.000ms |  0.001ms | 0.000ms |
| Lower                 | 428  |    5.473ms | 0.012ms | 0.001ms |  0.122ms | 0.026ms |
| **Total (per file)**  | 428  | **3093.059ms** | **7.226ms** | 5.548ms | 28.821ms | 8.871ms |

### After (native streaming preprocessor)

| Pass                 |   n  |    Total |    Mean |     Min |    Max |    p95 |
|----------------------|-----:|---------:|--------:|--------:|-------:|-------:|
| Parser               | 428  |  2.778ms | 0.006ms | 0.001ms | 0.055ms | 0.017ms |
| Resolver             | 428  |  0.291ms | 0.000ms | 0.000ms | 0.006ms | 0.001ms |
| Control              | 428  |  0.089ms | 0.000ms | 0.000ms | 0.001ms | 0.000ms |
| Typer                | 428  |  0.256ms | 0.000ms | 0.000ms | 0.003ms | 0.001ms |
| Desugar              | 428  |  0.020ms | 0.000ms | 0.000ms | 0.000ms | 0.000ms |
| Lower                | 428  |  2.347ms | 0.005ms | 0.000ms | 0.042ms | 0.015ms |
| **Total (per file)** | 428  | **5.784ms** | **0.013ms** | 0.002ms | 0.095ms | 0.036ms |

### Summary

| Metric                        | Before      | After    | Improvement       |
|-------------------------------|-------------|----------|-------------------|
| Total wall time (428 files)   | 3093.059ms  | 5.784ms  | **~534x faster**  |
| Mean time per file            | 7.226ms     | 0.013ms  | **~555x faster**  |
| p95 time per file             | 8.871ms     | 0.036ms  | **~246x faster**  |
| Compilation passes only       | 13.45ms     | 5.781ms  | **~2.3x faster**  |
