### PR TITLE
refactor(codemap): use global span address space to eliminate FileId from diagnostic

### DIFF
--- a/crates/jcc/src/ast/mod.rs
+++ b/crates/jcc/src/ast/mod.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 pub use ty::{Ty, TyKind};
 
-use jcc_backend::{
-    codemap::{file::FileId, span::Span},
-    Ident, IdentInterner,
-};
+use jcc_backend::{codemap::span::Span, Ident, IdentInterner};
 use jcc_entity::{entity_impl, EntityRef, EntitySlice, PrimaryMap, SlicePool};
 
 use std::cell::Cell;
@@ -36,8 +33,8 @@ pub struct Stmt(u32);
 entity_impl!(Stmt, "stmt");
 pub type Block = EntitySlice<BlockItem>;
 
+#[derive(Default)]
 pub struct Ast<'ctx> {
-    pub file: FileId,
     pub root: Vec<Decl>,
     pub decls: SlicePool<Decl>,
     pub exprs: SlicePool<Expr>,
@@ -48,23 +45,6 @@ pub struct Ast<'ctx> {
 }
 
 impl<'ctx> Ast<'ctx> {
-    pub fn new(file: FileId) -> Self {
-        Self::with_capacity(file, 256)
-    }
-
-    pub fn with_capacity(file: FileId, capacity: usize) -> Self {
-        Ast {
-            file,
-            root: Vec::with_capacity(capacity),
-            decls: SlicePool::with_capacity(capacity),
-            exprs: SlicePool::with_capacity(capacity),
-            items: SlicePool::with_capacity(capacity),
-            decl: PrimaryMap::with_capacity(capacity),
-            stmt: PrimaryMap::with_capacity(capacity),
-            expr: PrimaryMap::with_capacity(capacity),
-        }
-    }
-
     pub fn graphviz<'a>(&'a self, interner: &'a IdentInterner) -> AstGraphvizCtx<'a, 'ctx> {
         AstGraphvizCtx::new(self, interner)
     }

--- a/crates/jcc/src/ast/parse.rs
+++ b/crates/jcc/src/ast/parse.rs
@@ -10,11 +10,7 @@ use crate::{
 };
 
 use jcc_backend::{
-    codemap::{
-        file::{FileId, SourceFile},
-        span::Span,
-        Diagnostic, IntoDiagnostic, Issue, Label,
-    },
+    codemap::{file::SourceFile, span::Span, Diagnostic, IntoDiagnostic, Issue, Label},
     Ident, IdentInterner,
 };
 
@@ -56,11 +52,11 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
             file,
             interner,
             stream: PrepStream::new(file),
+            result: ParserResult::default(),
             specifiers: Vec::with_capacity(16),
             expr_stack: Vec::with_capacity(16),
             decl_stack: Vec::with_capacity(16),
             item_stack: Vec::with_capacity(16),
-            result: ParserResult::new(file.id()),
         }
     }
 
@@ -100,11 +96,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
     fn parse_type(&mut self, span: Span) -> Ty<'ctx> {
         match self.specifiers.as_slice() {
             [] => {
-                self.result.parser_issues.push(Issue::new(
-                    ParserIssue::MissingTypeSpecifier,
-                    self.file.id(),
-                    span,
-                ));
+                self.result
+                    .parser_issues
+                    .push(Issue::new(ParserIssue::MissingTypeSpecifier, span));
                 self.tys.void_ty
             }
             [TokenKind::KwVoid] => {
@@ -116,11 +110,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 self.tys.double_ty
             }
             specs if specs.contains(&TokenKind::KwDouble) || specs.contains(&TokenKind::KwVoid) => {
-                self.result.parser_issues.push(Issue::new(
-                    ParserIssue::InvalidTypeSpecifier,
-                    self.file.id(),
-                    span,
-                ));
+                self.result
+                    .parser_issues
+                    .push(Issue::new(ParserIssue::InvalidTypeSpecifier, span));
                 self.specifiers.clear();
                 self.tys.void_ty
             }
@@ -139,27 +131,21 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                         | TokenKind::KwLong
                         | TokenKind::KwSigned
                         | TokenKind::KwUnsigned => {
-                            self.result.parser_issues.push(Issue::new(
-                                ParserIssue::DuplicateTypeSpecifier,
-                                self.file.id(),
-                                span,
-                            ));
+                            self.result
+                                .parser_issues
+                                .push(Issue::new(ParserIssue::DuplicateTypeSpecifier, span));
                         }
                         _ => {
-                            self.result.parser_issues.push(Issue::new(
-                                ParserIssue::InvalidTypeSpecifier,
-                                self.file.id(),
-                                span,
-                            ));
+                            self.result
+                                .parser_issues
+                                .push(Issue::new(ParserIssue::InvalidTypeSpecifier, span));
                         }
                     }
                 }
                 if has_signed && has_unsigned {
-                    self.result.parser_issues.push(Issue::new(
-                        ParserIssue::ConflictingTypeSpecifiers,
-                        self.file.id(),
-                        span,
-                    ));
+                    self.result
+                        .parser_issues
+                        .push(Issue::new(ParserIssue::ConflictingTypeSpecifiers, span));
                 }
                 self.specifiers.clear();
                 match (has_unsigned, has_long) {
@@ -204,11 +190,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
 
         let span = start_span.merge(end_span);
         if count > 1 {
-            self.result.parser_issues.push(Issue::new(
-                ParserIssue::MultipleStorageClasses,
-                self.file.id(),
-                span,
-            ));
+            self.result
+                .parser_issues
+                .push(Issue::new(ParserIssue::MultipleStorageClasses, span));
         }
 
         (self.parse_type(span), storage)
@@ -300,7 +284,6 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
             _ => {
                 self.result.parser_issues.push(Issue::new(
                     ParserIssue::ExpectedToken(TokenKind::Semi),
-                    self.file.id(),
                     token.span,
                 ));
                 None
@@ -772,11 +755,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
                 }
             }
             _ => {
-                self.result.parser_issues.push(Issue::new(
-                    ParserIssue::UnexpectedToken,
-                    self.file.id(),
-                    span,
-                ));
+                self.result
+                    .parser_issues
+                    .push(Issue::new(ParserIssue::UnexpectedToken, span));
                 None
             }
         }
@@ -908,8 +889,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
         } else {
             self.result.parser_issues.push(Issue::new(
                 ParserIssue::UnexpectedEof,
-                self.file.id(),
-                Span::single(self.file.end_pos()),
+                Span::single(self.file.last()),
             ));
             None
         }
@@ -920,11 +900,9 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
         if token.kind == kind {
             self.next()
         } else {
-            self.result.parser_issues.push(Issue::new(
-                ParserIssue::ExpectedToken(kind),
-                self.file.id(),
-                token.span,
-            ));
+            self.result
+                .parser_issues
+                .push(Issue::new(ParserIssue::ExpectedToken(kind), token.span));
             None
         }
     }
@@ -934,8 +912,7 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
         self.next().or_else(|| {
             self.result.parser_issues.push(Issue::new(
                 ParserIssue::UnexpectedEof,
-                self.file.id(),
-                Span::single(self.file.end_pos()),
+                Span::single(self.file.last()),
             ));
             None
         })
@@ -953,7 +930,6 @@ impl<'a, 'ctx> Parser<'a, 'ctx> {
             _ => {
                 self.result.parser_issues.push(Issue::new(
                     ParserIssue::ExpectedToken(TokenKind::Identifier),
-                    self.file.id(),
                     token.span,
                 ));
                 None
@@ -1086,20 +1062,11 @@ impl From<TokenKind> for Option<Precedence> {
 // ParserResult
 // ---------------------------------------------------------------------------
 
+#[derive(Default)]
 pub struct ParserResult<'ctx> {
     pub ast: Ast<'ctx>,
     pub prep_issues: Vec<Issue<PrepIssue>>,
     pub parser_issues: Vec<Issue<ParserIssue>>,
-}
-
-impl ParserResult<'_> {
-    pub fn new(file: FileId) -> Self {
-        Self {
-            ast: Ast::new(file),
-            prep_issues: Vec::new(),
-            parser_issues: Vec::new(),
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1119,7 +1086,7 @@ pub enum ParserIssue {
 }
 
 impl IntoDiagnostic for ParserIssue {
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg, note): (Cow<str>, Cow<str>) = match self {
             ParserIssue::UnexpectedEof => (
                 "unexpected end of file".into(),
@@ -1155,7 +1122,7 @@ impl IntoDiagnostic for ParserIssue {
             ),
         };
         Diagnostic::error()
-            .with_label(Label::primary(file, span).with_message(msg))
+            .with_label(Label::primary(span).with_message(msg))
             .with_note(note)
     }
 }

--- a/crates/jcc/src/cli.rs
+++ b/crates/jcc/src/cli.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use jcc_backend::{
-    codemap::{color::ColorConfig, Diagnostic, Files, SimpleFiles},
+    codemap::{color::ColorConfig, simple::SimpleFiles, Diagnostic, Files},
     IdentInterner, TargetOs,
 };
 
@@ -132,21 +132,21 @@ impl CompileOptions {
 
 impl CompileOptions {
     pub fn run(&self, profiler: &mut Profiler) -> Result<()> {
-        let mut files = SimpleFiles::new();
-        let file = files
+        let mut db = SimpleFiles::new();
+        let file = db
             .add_file(&self.path)
             .context("failed to read source file")?;
-        let file = files.get(file).context("internal: file not in db")?;
+        let file = db.get(file).context("internal: file not in db")?;
 
         // Lexing, preprocessing, and parsing
         let tys = TyCtx::new();
         let mut interner = IdentInterner::new();
         let r = profiler.time("Parser", || Parser::new(file, &tys, &mut interner).parse());
-        check_pass(self, &mut files, "preprocessor", &r.prep_issues)?;
+        check_pass(self, &mut db, "preprocessor", &r.prep_issues)?;
         if self.stop_after == Some(Stage::Lex) {
             return Ok(());
         }
-        check_pass(self, &mut files, "parser", &r.parser_issues)?;
+        check_pass(self, &mut db, "parser", &r.parser_issues)?;
         if r.ast.root.is_empty() {
             return Err(anyhow::anyhow!("exiting due to empty parse tree"));
         }
@@ -157,12 +157,12 @@ impl CompileOptions {
         // Resolver, control flow analysis, and type checking
         let ast = r.ast;
         let r = profiler.time("Resolver", || ResolverPass::new(&ast).check());
-        check_pass(self, &mut files, "resolver", &r.issues)?;
+        check_pass(self, &mut db, "resolver", &r.issues)?;
         let mut ctx = SemaCtx::new(&tys, r.symbol_count);
         let r = profiler.time("Control", || ControlPass::new(&ast, &mut ctx).check());
-        check_pass(self, &mut files, "control", &r.issues)?;
+        check_pass(self, &mut db, "control", &r.issues)?;
         let r = profiler.time("Typer", || TypeChecker::new(&ast, &mut ctx).check());
-        check_pass(self, &mut files, "typer", &r.issues)?;
+        check_pass(self, &mut db, "typer", &r.issues)?;
         if self.stop_after == Some(Stage::Validate) {
             return Ok(());
         }

--- a/crates/jcc/src/lib.rs
+++ b/crates/jcc/src/lib.rs
@@ -6,3 +6,6 @@ pub mod prep;
 pub mod profile;
 pub mod sema;
 pub mod token;
+
+#[cfg(test)]
+mod testutil;

--- a/crates/jcc/src/prep/mod.rs
+++ b/crates/jcc/src/prep/mod.rs
@@ -65,19 +65,11 @@ impl<'a> Preprocessor<'a> {
 
     fn read_ident_inline(&mut self, span: Span) -> Result<Option<&'a str>, Issue<PrepIssue>> {
         match self.stream.next_on_line() {
-            Some(Err(e)) => Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
-            None => Err(Issue::new(
-                PrepIssue::ExpectedMacroName,
-                self.file.id(),
-                span,
-            )),
+            None => Err(Issue::new(PrepIssue::ExpectedMacroName, span)),
+            Some(Err(e)) => Err(Issue::new(PrepIssue::Lexer(e.kind), e.span)),
             Some(Ok(token)) => match token.kind {
                 TokenKind::Identifier => Ok(self.file.slice(token.span)),
-                _ => Err(Issue::new(
-                    PrepIssue::ExpectedMacroName,
-                    self.file.id(),
-                    token.span,
-                )),
+                _ => Err(Issue::new(PrepIssue::ExpectedMacroName, token.span)),
             },
         }
     }
@@ -86,7 +78,7 @@ impl<'a> Preprocessor<'a> {
         let span = match self.stream.next_on_line() {
             None => return Ok(()),
             Some(Ok(token)) => token.span,
-            Some(Err(e)) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
+            Some(Err(e)) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.span)),
         };
         let Some(keyword) = self.file.slice(span) else {
             return Ok(());
@@ -122,7 +114,7 @@ impl<'a> Preprocessor<'a> {
             "endif" => {
                 self.stream.skip_line();
                 if !self.stack.pop() {
-                    return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span));
+                    return Err(Issue::new(PrepIssue::UnmatchedEndif, span));
                 }
             }
             "else" => {
@@ -130,9 +122,7 @@ impl<'a> Preprocessor<'a> {
                 match self.stack.top() {
                     Some(CondState::False) => self.stack.set(CondState::True),
                     Some(_) => self.stack.set(CondState::Done),
-                    None => {
-                        return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span))
-                    }
+                    None => return Err(Issue::new(PrepIssue::UnmatchedEndif, span)),
                 }
             }
             "elif" => match self.stack.top() {
@@ -147,17 +137,13 @@ impl<'a> Preprocessor<'a> {
                 }
                 None => {
                     self.stream.skip_line();
-                    return Err(Issue::new(PrepIssue::UnmatchedEndif, self.file.id(), span));
+                    return Err(Issue::new(PrepIssue::UnmatchedEndif, span));
                 }
             },
             _ if self.stack.is_suppressed() => self.stream.skip_line(),
             "include" => {
                 self.stream.skip_line();
-                return Err(Issue::new(
-                    PrepIssue::IncludeNotSupported,
-                    self.file.id(),
-                    span,
-                ));
+                return Err(Issue::new(PrepIssue::IncludeNotSupported, span));
             }
             "undef" => {
                 let Some(name) = self.read_ident_inline(span)? else {
@@ -173,18 +159,14 @@ impl<'a> Preprocessor<'a> {
                 while let Some(item) = self.stream.next_on_line() {
                     match item {
                         Ok(token) => self.current.push(token),
-                        Err(e) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.file, e.span)),
+                        Err(e) => return Err(Issue::new(PrepIssue::Lexer(e.kind), e.span)),
                     }
                 }
                 self.macros.define(name, self.current.drain(..));
             }
             _ => {
                 self.stream.skip_line();
-                return Err(Issue::new(
-                    PrepIssue::UnknownDirective,
-                    self.file.id(),
-                    span,
-                ));
+                return Err(Issue::new(PrepIssue::UnknownDirective, span));
             }
         }
 
@@ -206,11 +188,7 @@ impl<'a> Iterator for Preprocessor<'a> {
                 }
                 None => match self.stream.next()? {
                     Err(issue) => {
-                        return Some(Err(Issue::new(
-                            PrepIssue::Lexer(issue.kind),
-                            issue.file,
-                            issue.span,
-                        )));
+                        return Some(Err(Issue::new(PrepIssue::Lexer(issue.kind), issue.span)));
                     }
                     Ok(token) => match token.kind {
                         TokenKind::CommentBlock | TokenKind::CommentInline => continue,
@@ -246,9 +224,9 @@ pub enum PrepIssue {
 }
 
 impl IntoDiagnostic for PrepIssue {
-    fn into_diagnostic(self, file: jcc_backend::codemap::file::FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg1, msg2, note) = match self {
-            PrepIssue::Lexer(issue) => return issue.into_diagnostic(file, span),
+            PrepIssue::Lexer(issue) => return issue.into_diagnostic(span),
             PrepIssue::UnmatchedEndif => ("unmatched `#endif` or `#else`", "no matching `#if`", None),
             PrepIssue::IncludeNotSupported => ("`#include` is not yet implemented", "`#include` is not supported", None),
             PrepIssue::ExpectedMacroName => ("expected an identifier after preprocessor directive", "expected a macro name here", None),
@@ -258,6 +236,6 @@ impl IntoDiagnostic for PrepIssue {
         Diagnostic::error()
             .with_notes(note)
             .with_message(msg1)
-            .with_label(Label::primary(file, span).with_message(msg2))
+            .with_label(Label::primary(span).with_message(msg2))
     }
 }

--- a/crates/jcc/src/prep/stream.rs
+++ b/crates/jcc/src/prep/stream.rs
@@ -53,12 +53,7 @@ impl<'a> PrepStream<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::token::TokenKind;
-    use jcc_backend::codemap::file::{FileId, SourceFile};
-
-    fn file(src: &str) -> SourceFile {
-        SourceFile::from_source(FileId::new(0), "<test>", format!("{src}\n"))
-    }
+    use crate::{testutil::file, token::TokenKind};
 
     #[test]
     fn peek_does_not_consume() {

--- a/crates/jcc/src/sema/control.rs
+++ b/crates/jcc/src/sema/control.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use jcc_backend::{
-    codemap::{file::FileId, span::Span, Diagnostic, IntoDiagnostic, Issue, Label},
+    codemap::{span::Span, Diagnostic, IntoDiagnostic, Issue, Label},
     Ident,
 };
 use jcc_entity::EntityMap;
@@ -55,11 +55,9 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                         self.tracked_labels.values().for_each(|e| {
                             if let TrackedLabel::Unresolved(v) = e {
                                 v.iter().for_each(|(_, span)| {
-                                    self.result.issues.push(Issue::new(
-                                        ControlIssue::UndefinedLabel,
-                                        self.ast.file,
-                                        *span,
-                                    ));
+                                    self.result
+                                        .issues
+                                        .push(Issue::new(ControlIssue::UndefinedLabel, *span));
                                 });
                             }
                         });
@@ -127,11 +125,10 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                 Some(TrackedStmt::Loop(stmt)) | Some(TrackedStmt::Switch(stmt)) => {
                     target.set(Some(*stmt))
                 }
-                None => self.result.issues.push(Issue::new(
-                    ControlIssue::UndefinedLoopOrSwitch,
-                    self.ast.file,
-                    data.span,
-                )),
+                None => self
+                    .result
+                    .issues
+                    .push(Issue::new(ControlIssue::UndefinedLoopOrSwitch, data.span)),
             },
             StmtKind::Continue(target) => {
                 match self.tracked_stmts.iter().rev().find_map(|stmt| match stmt {
@@ -141,11 +138,10 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                     Some(stmt) => {
                         target.set(Some(stmt));
                     }
-                    None => self.result.issues.push(Issue::new(
-                        ControlIssue::UndefinedLoop,
-                        self.ast.file,
-                        data.span,
-                    )),
+                    None => self
+                        .result
+                        .issues
+                        .push(Issue::new(ControlIssue::UndefinedLoop, data.span)),
                 }
             }
             StmtKind::Case { stmt: inner, .. } => {
@@ -160,11 +156,10 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                         .or_default()
                         .cases
                         .push(stmt),
-                    _ => self.result.issues.push(Issue::new(
-                        ControlIssue::CaseOutsideSwitch,
-                        self.ast.file,
-                        data.span,
-                    )),
+                    _ => self
+                        .result
+                        .issues
+                        .push(Issue::new(ControlIssue::CaseOutsideSwitch, data.span)),
                 }
                 self.visit_stmt(*inner);
             }
@@ -177,18 +172,16 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                         let switch = self.ctx.switches.entry(*switch_stmt).or_default();
                         match switch.default {
                             None => switch.default = Some(stmt),
-                            Some(_) => self.result.issues.push(Issue::new(
-                                ControlIssue::DuplicateDefault,
-                                self.ast.file,
-                                data.span,
-                            )),
+                            Some(_) => self
+                                .result
+                                .issues
+                                .push(Issue::new(ControlIssue::DuplicateDefault, data.span)),
                         }
                     }
-                    _ => self.result.issues.push(Issue::new(
-                        ControlIssue::CaseOutsideSwitch,
-                        self.ast.file,
-                        data.span,
-                    )),
+                    _ => self
+                        .result
+                        .issues
+                        .push(Issue::new(ControlIssue::CaseOutsideSwitch, data.span)),
                 }
                 self.visit_stmt(*inner);
             }
@@ -206,11 +199,9 @@ impl<'a, 'ctx> ControlPass<'a, 'ctx> {
                             }
                             TrackedLabel::Resolved(s) => {
                                 if stmt != *s {
-                                    self.result.issues.push(Issue::new(
-                                        ControlIssue::RedeclaredLabel,
-                                        self.ast.file,
-                                        data.span,
-                                    ));
+                                    self.result
+                                        .issues
+                                        .push(Issue::new(ControlIssue::RedeclaredLabel, data.span));
                                 }
                             }
                         }
@@ -257,7 +248,7 @@ pub enum ControlIssue {
 }
 
 impl IntoDiagnostic for ControlIssue {
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg, note) = match self {
             ControlIssue::UndefinedLoop => (
                 "break/continue outside of loop",
@@ -285,7 +276,7 @@ impl IntoDiagnostic for ControlIssue {
             ),
         };
         Diagnostic::error()
-            .with_label(Label::primary(file, span).with_message(msg))
+            .with_label(Label::primary(span).with_message(msg))
             .with_note(note)
     }
 }

--- a/crates/jcc/src/sema/resolve.rs
+++ b/crates/jcc/src/sema/resolve.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use jcc_backend::{
-    codemap::{file::FileId, span::Span, Diagnostic, IntoDiagnostic, Issue, Label},
+    codemap::{span::Span, Diagnostic, IntoDiagnostic, Issue, Label},
     interner::symtab::EntitySymbolTable,
     Ident,
 };
@@ -91,7 +91,6 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
                 if let Some(StorageClass::Static) = data.storage {
                     self.result.issues.push(Issue::new(
                         ResolverIssue::IllegalLocalStaticFunction,
-                        self.ast.file,
                         data.span,
                     ));
                 }
@@ -99,7 +98,6 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
                     Some(_) => {
                         self.result.issues.push(Issue::new(
                             ResolverIssue::IllegalLocalFunctionDefinition,
-                            self.ast.file,
                             data.span,
                         ));
                     }
@@ -110,11 +108,9 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
                             .insert(data.name.name, SymbolInfo::with_linkage(symbol))
                         {
                             if !prev.has_linkage {
-                                self.result.issues.push(Issue::new(
-                                    ResolverIssue::ConflictingSymbol,
-                                    self.ast.file,
-                                    data.span,
-                                ));
+                                self.result
+                                    .issues
+                                    .push(Issue::new(ResolverIssue::ConflictingSymbol, data.span));
                             }
                         }
                     }
@@ -218,20 +214,18 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
             }
             ExprKind::Var(name) => match self.scope.get(&name.name) {
                 Some(entry) => name.sema.set(Some(entry.symbol)),
-                None => self.result.issues.push(Issue::new(
-                    ResolverIssue::UndeclaredVariable,
-                    self.ast.file,
-                    data.span,
-                )),
+                None => self
+                    .result
+                    .issues
+                    .push(Issue::new(ResolverIssue::UndeclaredVariable, data.span)),
             },
             ExprKind::Call { name, args } => {
                 match self.scope.get(&name.name) {
                     Some(entry) => name.sema.set(Some(entry.symbol)),
-                    None => self.result.issues.push(Issue::new(
-                        ResolverIssue::UndeclaredFunction,
-                        self.ast.file,
-                        data.span,
-                    )),
+                    None => self
+                        .result
+                        .issues
+                        .push(Issue::new(ResolverIssue::UndeclaredFunction, data.span)),
                 }
                 self.ast.exprs[*args]
                     .iter()
@@ -268,7 +262,6 @@ impl<'a, 'ctx> ResolverPass<'a, 'ctx> {
             if !(entry.has_linkage && prev.has_linkage) {
                 self.result.issues.push(Issue::new(
                     ResolverIssue::ConflictingSymbol,
-                    self.ast.file,
                     self.ast.decl[decl].span,
                 ));
             }
@@ -320,7 +313,7 @@ pub enum ResolverIssue {
 }
 
 impl IntoDiagnostic for ResolverIssue {
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg, note) = match self {
             ResolverIssue::ConflictingSymbol => (
                 "symbol conflicts with previous declaration",
@@ -352,7 +345,7 @@ impl IntoDiagnostic for ResolverIssue {
             ),
         };
         Diagnostic::error()
-            .with_label(Label::primary(file, span).with_message(msg))
+            .with_label(Label::primary(span).with_message(msg))
             .with_note(note)
     }
 }

--- a/crates/jcc/src/sema/typing.rs
+++ b/crates/jcc/src/sema/typing.rs
@@ -9,7 +9,7 @@ use crate::{
     sema::{Attribute, SemaCtx, StaticValue, SymbolInfo},
 };
 
-use jcc_backend::codemap::{file::FileId, span::Span, Diagnostic, IntoDiagnostic, Issue, Label};
+use jcc_backend::codemap::{span::Span, Diagnostic, IntoDiagnostic, Issue, Label};
 
 use std::collections::HashSet;
 
@@ -83,11 +83,9 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                     info.get_or_insert(SymbolInfo::statik(data.ty, decl_is_global, decl_init));
 
                 if info.ty != data.ty {
-                    self.result.issues.push(Issue::new(
-                        TypeIssue::DeclarationTypeMismatch,
-                        self.ast.file,
-                        data.span,
-                    ));
+                    self.result
+                        .issues
+                        .push(Issue::new(TypeIssue::DeclarationTypeMismatch, data.span));
                 }
 
                 if let Attribute::Static {
@@ -100,7 +98,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                     {
                         self.result.issues.push(Issue::new(
                             TypeIssue::DeclarationVisibilityMismatch,
-                            self.ast.file,
                             data.span,
                         ));
                     }
@@ -187,11 +184,9 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                 .get_or_insert(SymbolInfo::function(decl.ty, decl_is_global, false));
 
             if entry.ty != decl.ty {
-                self.result.issues.push(Issue::new(
-                    TypeIssue::DeclarationTypeMismatch,
-                    self.ast.file,
-                    decl.span,
-                ));
+                self.result
+                    .issues
+                    .push(Issue::new(TypeIssue::DeclarationTypeMismatch, decl.span));
             }
 
             if let Attribute::Function {
@@ -202,7 +197,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                 if is_global && !decl_is_global {
                     self.result.issues.push(Issue::new(
                         TypeIssue::DeclarationVisibilityMismatch,
-                        self.ast.file,
                         decl.span,
                     ));
                 }
@@ -217,7 +211,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                     if self.ast.decl[*param].storage.is_some() {
                         self.result.issues.push(Issue::new(
                             TypeIssue::StorageClassesDisallowed,
-                            self.ast.file,
                             self.ast.decl[*param].span,
                         ));
                     }
@@ -293,7 +286,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                             if self.ast.decl[*decl].storage.is_some() {
                                 self.result.issues.push(Issue::new(
                                     TypeIssue::StorageClassesDisallowed,
-                                    self.ast.file,
                                     self.ast.decl[*decl].span,
                                 ));
                             }
@@ -320,7 +312,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                                 None => {
                                     self.result.issues.push(Issue::new(
                                         TypeIssue::NotConstant,
-                                        self.ast.file,
                                         self.ast.expr[*expr].span,
                                     ));
                                 }
@@ -329,7 +320,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                                         if !self.switch_cases.insert(val) {
                                             self.result.issues.push(Issue::new(
                                                 TypeIssue::DuplicateSwitchCase,
-                                                self.ast.file,
                                                 self.ast.expr[*expr].span,
                                             ));
                                         }
@@ -337,7 +327,6 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
                                     None => {
                                         self.result.issues.push(Issue::new(
                                             TypeIssue::ConstantOutOfRange,
-                                            self.ast.file,
                                             self.ast.expr[*expr].span,
                                         ));
                                     }
@@ -547,9 +536,7 @@ impl<'a, 'ctx> TypeChecker<'a, 'ctx> {
     // ---------------------------------------------------------------------------
 
     fn emit(&mut self, span: Span, kind: TypeIssue) {
-        self.result
-            .issues
-            .push(Issue::new(kind, self.ast.file, span));
+        self.result.issues.push(Issue::new(kind, span));
     }
 
     fn assert_is_lvalue(&mut self, expr: Expr) -> bool {
@@ -610,7 +597,7 @@ pub enum TypeIssue {
 }
 
 impl IntoDiagnostic for TypeIssue {
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg, note) = match self {
             TypeIssue::ConstantOutOfRange => (
                 "constant value is out of range for the target type",
@@ -678,7 +665,7 @@ impl IntoDiagnostic for TypeIssue {
             ),
         };
         Diagnostic::error()
-            .with_label(Label::primary(file, span).with_message(msg))
+            .with_label(Label::primary(span).with_message(msg))
             .with_note(note)
     }
 }

--- a/crates/jcc/src/testutil.rs
+++ b/crates/jcc/src/testutil.rs
@@ -1,0 +1,5 @@
+use jcc_backend::codemap::{byte::BytePos, file::SourceFile};
+
+pub fn file(src: &str) -> SourceFile {
+    SourceFile::from_source(BytePos::ZERO, "<test>", format!("{src}\n"))
+}

--- a/crates/jcc/src/token/lex.rs
+++ b/crates/jcc/src/token/lex.rs
@@ -1,10 +1,7 @@
 use super::{Token, TokenKind};
 
 use jcc_backend::codemap::{
-    byte::BytePos,
-    file::{FileId, SourceFile},
-    span::Span,
-    Diagnostic, IntoDiagnostic, Issue, Label,
+    file::SourceFile, span::Span, Diagnostic, IntoDiagnostic, Issue, Label,
 };
 
 use std::{
@@ -18,7 +15,7 @@ use std::{
 
 #[derive(Clone)]
 pub struct Lexer<'a> {
-    pos: BytePos,
+    pos: usize,
     line_start: bool,
     file: &'a SourceFile,
     chars: Peekable<CharIndices<'a>>,
@@ -36,14 +33,14 @@ impl<'a> Iterator for Lexer<'a> {
             self.line_start = *c == '\n';
             let idx = self.chars.next()?.0;
             if self.line_start {
-                self.pos = BytePos::from(idx);
+                self.pos = idx;
                 return Some(Ok(Token::new(TokenKind::NewLine, self.span(1))));
             }
         }
         let can_emit_hash = self.line_start;
         let (idx, c) = self.chars.next()?;
-        self.pos = BytePos::from(idx);
         self.line_start = false;
+        self.pos = idx;
         Some(match c {
             c if c.is_ascii_digit() => self.number(false),
             c if c.is_ascii_alphabetic() || c == '_' => Ok(self.word()),
@@ -52,8 +49,7 @@ impl<'a> Iterator for Lexer<'a> {
                 Some((_, c)) if c.is_ascii_digit() => self.number(true),
                 _ => Err(Issue::new(
                     LexerIssue::UnexpectedCharacter,
-                    self.file.id(),
-                    Span::single(self.pos),
+                    self.file.single(self.pos),
                 )),
             },
             ';' => Ok(Token::new(TokenKind::Semi, self.span(1))),
@@ -111,8 +107,7 @@ impl<'a> Iterator for Lexer<'a> {
             },
             _ => Err(Issue::new(
                 LexerIssue::UnexpectedCharacter,
-                self.file.id(),
-                Span::single(self.pos),
+                self.file.single(self.pos),
             )),
         })
     }
@@ -122,15 +117,16 @@ impl<'a> Lexer<'a> {
     pub fn new(file: &'a SourceFile) -> Self {
         Self {
             file,
+            pos: 0,
             line_start: true,
-            pos: BytePos::ZERO,
             chars: file.source().char_indices().peekable(),
         }
     }
 
+    /// Creates a global span of `len` bytes starting at the current position.
     #[inline]
-    fn span(&self, len: u32) -> Span {
-        Span::new(self.pos, self.pos + len).unwrap()
+    fn span(&self, len: usize) -> Span {
+        self.file.span(self.pos, self.pos + len).unwrap()
     }
 
     #[inline]
@@ -198,7 +194,10 @@ impl<'a> Lexer<'a> {
             .peek()
             .map(|(idx, _)| *idx as u32)
             .unwrap_or(self.file.source().len() as u32);
-        Token::new(TokenKind::CommentInline, Span::new(self.pos, end).unwrap())
+        Token::new(
+            TokenKind::CommentInline,
+            self.file.span(self.pos, end).unwrap(),
+        )
     }
 
     fn comment_block(&mut self) -> Result<Token, Issue<LexerIssue>> {
@@ -216,18 +215,14 @@ impl<'a> Lexer<'a> {
             .peek()
             .map(|(idx, _)| *idx as u32)
             .unwrap_or(self.file.source().len() as u32);
-        let span = Span::new(self.pos, end).unwrap();
+        let span = self.file.span(self.pos, end).unwrap();
         if closed {
             Ok(Token {
                 span,
                 kind: TokenKind::CommentBlock,
             })
         } else {
-            Err(Issue::new(
-                LexerIssue::UnclosedBlockComment,
-                self.file.id(),
-                span,
-            ))
+            Err(Issue::new(LexerIssue::UnclosedBlockComment, span))
         }
     }
 
@@ -257,12 +252,11 @@ impl<'a> Lexer<'a> {
                     let end = self
                         .chars
                         .peek()
-                        .map(|(idx, _)| *idx as u32)
-                        .unwrap_or(self.file.source().len() as u32);
+                        .map(|(idx, _)| *idx)
+                        .unwrap_or(self.file.source().len());
                     return Err(Issue::new(
                         LexerIssue::EmptyExponent,
-                        self.file.id(),
-                        Span::new(self.pos, end).unwrap(),
+                        self.file.span(self.pos, end).unwrap(),
                     ));
                 }
             }
@@ -297,41 +291,35 @@ impl<'a> Lexer<'a> {
         };
 
         let end = match self.chars.peek() {
-            None => self.file.source().len() as u32,
+            None => self.file.source().len(),
             Some((end, c)) => {
-                let end = *end as u32;
                 if c.is_ascii_alphanumeric() || *c == '_' || *c == '.' {
                     return Err(Issue::new(
                         LexerIssue::InvalidNumberSuffix,
-                        self.file.id(),
-                        Span::new(self.pos, end).unwrap(),
+                        self.file.span(self.pos, *end).unwrap(),
                     ));
                 }
-                end
+                *end
             }
         };
 
         Ok(Token {
             kind,
-            span: Span::new(self.pos, end).unwrap(),
+            span: self.file.span(self.pos, end).unwrap(),
         })
     }
 
     fn word(&mut self) -> Token {
         let end = self.next_while(|c| c.is_ascii_alphanumeric() || c == '_');
-        let ident = self
-            .file
-            .source()
-            .get(self.pos.to_usize()..end.to_usize())
-            .unwrap_or_default();
+        let ident = self.file.source().get(self.pos..end).unwrap_or_default();
         Token {
-            span: Span::new(self.pos, end).unwrap(),
+            span: self.file.span(self.pos, end).unwrap(),
             kind: TokenKind::from_keyword(ident).unwrap_or(TokenKind::Identifier),
         }
     }
 
     #[inline]
-    fn next_while<F>(&mut self, mut predicate: F) -> BytePos
+    fn next_while<F>(&mut self, mut predicate: F) -> usize
     where
         F: FnMut(char) -> bool,
     {
@@ -343,7 +331,7 @@ impl<'a> Lexer<'a> {
         }
         self.chars
             .peek()
-            .map(|(idx, _)| BytePos::from(*idx))
+            .map(|(idx, _)| *idx)
             .unwrap_or(self.pos + 1)
     }
 }
@@ -361,7 +349,7 @@ pub enum LexerIssue {
 }
 
 impl IntoDiagnostic for LexerIssue {
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic {
+    fn into_diagnostic(self, span: Span) -> Diagnostic {
         let (msg, note) = match self {
             LexerIssue::EmptyExponent => (
                 "empty exponent",
@@ -381,7 +369,7 @@ impl IntoDiagnostic for LexerIssue {
             ),
         };
         Diagnostic::error()
-            .with_label(Label::primary(file, span).with_message(msg))
+            .with_label(Label::primary(span).with_message(msg))
             .with_note(note)
     }
 }

--- a/crates/jcc/src/token/stream.rs
+++ b/crates/jcc/src/token/stream.rs
@@ -99,12 +99,7 @@ impl<'a> TokenStream<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::token::lex::Lexer;
-    use jcc_backend::codemap::file::{FileId, SourceFile};
-
-    fn file(src: &str) -> SourceFile {
-        SourceFile::from_source(FileId::new(0), "<test>", format!("{src}\n"))
-    }
+    use crate::{testutil::file, token::lex::Lexer};
 
     fn kinds(src: &str) -> Vec<TokenKind> {
         let file = file(src);

--- a/crates/jcc_codemap/src/color.rs
+++ b/crates/jcc_codemap/src/color.rs
@@ -47,14 +47,11 @@
 //! The main cost is the additional function calls to set colors, which are negligible
 //! for typical diagnostic use cases.
 
-#[cfg(feature = "color")]
 use termcolor::{Color, ColorSpec, WriteColor};
 
-#[cfg(feature = "color")]
 use crate::{Diagnostic, Files, Label, Location};
 
 /// Configuration for colored diagnostic output.
-#[cfg(feature = "color")]
 #[derive(Debug, Clone)]
 pub struct ColorConfig {
     /// Color for error severity
@@ -73,7 +70,6 @@ pub struct ColorConfig {
     pub line_number: Color,
 }
 
-#[cfg(feature = "color")]
 impl Default for ColorConfig {
     fn default() -> Self {
         Self {
@@ -88,7 +84,6 @@ impl Default for ColorConfig {
     }
 }
 
-#[cfg(feature = "color")]
 struct ColorSpecConfig {
     /// Color specification for error severity
     error: ColorSpec,
@@ -133,7 +128,6 @@ impl From<&ColorConfig> for ColorSpecConfig {
 /// # Errors
 ///
 /// If writing to the writer fails, an error is returned.
-#[cfg(feature = "color")]
 pub fn emit_diagnostic_colored<F: Files, W: WriteColor>(
     files: &F,
     diagnostic: &Diagnostic,
@@ -155,12 +149,13 @@ pub fn emit_diagnostic_colored<F: Files, W: WriteColor>(
     }
     writer.reset()?;
     writeln!(writer, ": {}", diagnostic.message)?;
-    for (file, labels) in group_labels(&diagnostic.labels) {
-        let name = files
-            .name(file)
-            .map_or_else(|| format!("{file:?}"), |p| p.display().to_string());
+    for (file, labels) in group_labels(files, &diagnostic.labels) {
+        let name = labels
+            .first()
+            .and_then(|l| files.file_for_pos(l.span.start()))
+            .map_or_else(|| format!("{file:?}"), |f| f.name().display().to_string());
         for label in labels {
-            if let Some(location) = files.location(file, label.span) {
+            if let Some(location) = files.location(label.span) {
                 emit_label_colored(writer, &name, &location, label, &config)?;
             }
         }
@@ -179,7 +174,6 @@ pub fn emit_diagnostic_colored<F: Files, W: WriteColor>(
 /// # Errors
 ///
 /// If writing to the writer fails for any reason, an error is returned.
-#[cfg(feature = "color")]
 fn emit_label_colored<W: WriteColor>(
     writer: &mut W,
     file: &str,
@@ -302,7 +296,7 @@ fn emit_label_colored<W: WriteColor>(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::{file::FileId, span::Span, SimpleFiles};
+    use crate::{simple::SimpleFiles, testutil::create_test_files};
 
     use termcolor::{Color, ColorSpec, WriteColor};
 
@@ -360,34 +354,6 @@ mod tests {
         }
     }
 
-    struct TestFiles {
-        files: SimpleFiles,
-        test_file: FileId,
-        example_file: FileId,
-        unicode_file: FileId,
-    }
-
-    fn create_test_files() -> TestFiles {
-        let mut files = SimpleFiles::new();
-        let test_file = files.add("test.rs", "let x = 5;".to_string());
-        let unicode_file = files.add("unicode.rs", "let café = \"☕\";".to_string());
-        let example_file = files.add(
-            "example.rs",
-            r#"fn main() {
-    let x = 5;
-    let y = x + "hello";
-    println!("{}", y);
-}"#
-            .to_string(),
-        );
-        TestFiles {
-            files,
-            test_file,
-            example_file,
-            unicode_file,
-        }
-    }
-
     fn emit_colored_to_string(files: &SimpleFiles, diagnostic: &Diagnostic) -> String {
         let config = ColorConfig::default();
         let mut writer = MockWriter::default();
@@ -410,7 +376,7 @@ mod tests {
         let diagnostic = Diagnostic::help()
             .with_message("this is a help message")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("consider changing this"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -431,8 +397,7 @@ mod tests {
         let diagnostic = Diagnostic::note()
             .with_message("this is a note message")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
-                    .with_message("just so you know"),
+                Label::primary(files.span(files.test_file, 4, 5)).with_message("just so you know"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
         let expected = "\
@@ -452,7 +417,7 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("variable not found")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("not found in this scope"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -473,7 +438,7 @@ mod tests {
         let diagnostic = Diagnostic::warning()
             .with_message("unused variable: `x`")
             .with_label(
-                Label::primary(files.example_file, Span::new(20u32, 21u32).unwrap())
+                Label::primary(files.span(files.example_file, 20, 21))
                     .with_message("help: if this is intentional, prefix with underscore: `_x`"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -495,7 +460,7 @@ mod tests {
             .with_code("E0425")
             .with_message("cannot find value `z` in this scope")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("not found in this scope"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -515,10 +480,7 @@ mod tests {
         let files = create_test_files();
         let diagnostic = Diagnostic::error()
             .with_message("cannot borrow as mutable")
-            .with_label(Label::primary(
-                files.test_file,
-                Span::new(0u32, 3u32).unwrap(),
-            ))
+            .with_label(Label::primary(files.span(files.test_file, 0, 3)))
             .with_note("consider changing this to be mutable: `mut x`")
             .with_note("see documentation on borrowing for more information");
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -556,7 +518,7 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("expected expression")
             .with_label(
-                Label::primary(files.test_file, Span::new(3u32, 3u32).unwrap())
+                Label::primary(files.span(files.test_file, 3, 3))
                     .with_message("expected expression here"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -574,13 +536,9 @@ mod tests {
     #[test]
     fn test_label_without_message() {
         let files = create_test_files();
-        let diagnostic =
-            Diagnostic::error()
-                .with_message("syntax error")
-                .with_label(Label::primary(
-                    files.test_file,
-                    Span::new(4u32, 5u32).unwrap(),
-                ));
+        let diagnostic = Diagnostic::error()
+            .with_message("syntax error")
+            .with_label(Label::primary(files.span(files.test_file, 4, 5)));
         let output = emit_colored_to_string(&files.files, &diagnostic);
         let expected = "\
 [Red!]error[Reset]: syntax error
@@ -598,7 +556,7 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("invalid character in identifier")
             .with_label(
-                Label::primary(files.unicode_file, Span::new(4u32, 8u32).unwrap())
+                Label::primary(files.span(files.unicode_file, 4, 8))
                     .with_message("unexpected character"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -619,7 +577,7 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("missing semicolon")
             .with_label(
-                Label::primary(files.test_file, Span::new(9u32, 10u32).unwrap())
+                Label::primary(files.span(files.test_file, 9, 10))
                     .with_message("expected `;` here"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -640,7 +598,7 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("unclosed delimiter")
             .with_label(
-                Label::primary(files.example_file, Span::new(0u32, 74u32).unwrap())
+                Label::primary(files.span(files.example_file, 0, 74))
                     .with_message("function body not closed"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -667,11 +625,9 @@ mod tests {
         let diagnostic = Diagnostic::note()
             .with_message("related information")
             .with_label(
-                Label::secondary(files.test_file, Span::new(4u32, 5u32).unwrap())
-                    .with_message("defined here"),
+                Label::secondary(files.span(files.test_file, 4, 5)).with_message("defined here"),
             );
         let output = emit_colored_to_string(&files.files, &diagnostic);
-        // Secondary labels usually use Cyan or Blue to distinguish from the primary color
         let expected = "\
 [Cyan!]note[Reset]: related information
   [Blue!]-->[Reset] test.rs:1:5
@@ -689,9 +645,9 @@ mod tests {
         let diagnostic = Diagnostic::error()
             .with_message("mismatched types")
             .with_labels(vec![
-                Label::primary(files.example_file, Span::new(37u32, 38u32).unwrap())
+                Label::primary(files.span(files.example_file, 37, 38))
                     .with_message("expected integer"),
-                Label::secondary(files.example_file, Span::new(43u32, 50u32).unwrap())
+                Label::secondary(files.span(files.example_file, 43, 50))
                     .with_message("this is a string"),
             ]);
         let output = emit_colored_to_string(&files.files, &diagnostic);
@@ -718,9 +674,9 @@ mod tests {
             .with_code("E0308")
             .with_message("mismatched types")
             .with_labels(vec![
-                Label::primary(files.example_file, Span::new(37u32, 38u32).unwrap())
+                Label::primary(files.span(files.example_file, 37, 38))
                     .with_message("expected `i32`, found `&str`"),
-                Label::secondary(files.example_file, Span::new(20u32, 21u32).unwrap())
+                Label::secondary(files.span(files.example_file, 20, 21))
                     .with_message("`x` is defined here as `i32`"),
             ])
             .with_note("expected type `i32`")

--- a/crates/jcc_codemap/src/file.rs
+++ b/crates/jcc_codemap/src/file.rs
@@ -10,63 +10,50 @@
 //! - The complete source text as a string
 //! - A file name or path for display purposes
 //! - An index of byte positions where each line begins
+//! - A global base offset in the shared address space (see below)
 //!
 //! The line index is computed once when the file is created, making subsequent line/column
 //! lookups extremely fast using binary search.
+//!
+//! # Global Address Space
+//!
+//! All source files share a single virtual address space managed by the file database
+//! (e.g., [`crate::SimpleFiles`]). Each file is allocated a non-overlapping range
+//! `[base, base + len)` in this space. Spans produced by lexing and parsing carry
+//! global byte positions, so a [`crate::span::Span`] alone identifies both the file
+//! and the location within it.
+//!
+//! Methods on [`SourceFile`] that accept positions or spans (`slice`, `line_col`,
+//! `location`) expect global values and translate them to file-local offsets internally.
 //!
 //! # Unicode Handling
 //!
 //! Column numbers are counted in **characters** (Unicode scalar values), not bytes.
 //! This ensures that the column numbers match what users see in their editors.
 
-use std::{
-    ops::Range,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use crate::{byte::BytePos, span::Span, LineCol, Location};
-
-/// An opaque identifier for a source file.
-///
-/// This is used to reference files in a Files database.
-/// File IDs are stable and can be stored in your AST or IR.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FileId(u32);
-
-impl FileId {
-    /// Creates a new `FileId` from a u32.
-    #[inline]
-    pub fn new(id: u32) -> Self {
-        Self(id)
-    }
-
-    /// Returns the underlying u32 value.
-    #[inline]
-    pub fn as_u32(self) -> u32 {
-        self.0
-    }
-
-    /// Returns the underlying usize value.
-    #[inline]
-    pub fn as_usize(self) -> usize {
-        self.0 as usize
-    }
-}
 
 /// A single source file with line index information.
 ///
 /// This stores the source text and pre-computed line start positions
 /// for efficient line/column lookups.
+///
+/// All positions and spans accepted by methods on this type are global
+/// (i.e., offset from the start of the shared address space, not from the
+/// start of this file). The file's [`base`](Self::base) is subtracted internally
+/// before any string operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceFile {
-    /// The unique identifier for this file
-    id: FileId,
-    /// The name or path of this file
+    /// Start of the file in the shared address space.
+    base: BytePos,
+    /// The name or path of this file.
     name: PathBuf,
-    /// The source text
+    /// The source text.
     source: String,
-    /// Byte positions of the start of each line
-    /// Always starts with 0 for the first line
+    /// File-local byte positions of the start of each line.
+    /// Always starts with `BytePos(0)` for the first line.
     line_starts: Vec<BytePos>,
 }
 
@@ -76,12 +63,12 @@ impl SourceFile {
     /// # Errors
     ///
     /// If reading the file fails, an error is returned.
-    pub fn new(id: FileId, path: impl AsRef<Path>) -> std::io::Result<Self> {
+    pub fn new(base: BytePos, path: impl AsRef<Path>) -> std::io::Result<Self> {
         let path = path.as_ref();
         let source = std::fs::read_to_string(path)?;
         let line_starts = compute_line_starts(&source);
         Ok(Self {
-            id,
+            base,
             source,
             line_starts,
             name: path.to_path_buf(),
@@ -89,20 +76,14 @@ impl SourceFile {
     }
 
     /// Creates a source file from source text with the given name.
-    pub fn from_source(id: FileId, name: impl Into<PathBuf>, source: String) -> Self {
+    pub fn from_source(base: BytePos, name: impl Into<PathBuf>, source: String) -> Self {
         let line_starts = compute_line_starts(&source);
         Self {
-            id,
+            base,
             source,
             line_starts,
             name: name.into(),
         }
-    }
-
-    /// Returns the unique identifier for this file.
-    #[inline]
-    pub fn id(&self) -> FileId {
-        self.id
     }
 
     /// Returns the name of this file.
@@ -117,41 +98,69 @@ impl SourceFile {
         &self.source
     }
 
+    /// Returns the global base offset of this file.
+    #[inline]
+    pub fn base(&self) -> BytePos {
+        self.base
+    }
+
     /// Returns the number of lines in this file.
     #[inline]
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
     }
 
-    /// Gets the byte position at the end of the file.
+    /// Returns the global byte position one past the last byte of this file.
     #[inline]
-    pub fn end_pos(&self) -> BytePos {
-        BytePos(self.source.len().try_into().unwrap_or(u32::MAX))
+    pub fn end(&self) -> BytePos {
+        self.base + u32::try_from(self.source.len()).unwrap_or(u32::MAX)
     }
 
-    /// Gets a slice of the source text for the given span.
+    /// Returns the global byte position of the last byte in this file.
+    #[inline]
+    pub fn last(&self) -> BytePos {
+        self.base + u32::try_from(self.source.len() - 1).unwrap_or(u32::MAX)
+    }
+
+    /// Gets a slice of the source text for the given a global span.
+    ///
+    /// Returns `None` if the span does not fall within this file's address range.
     #[inline]
     pub fn slice(&self, span: Span) -> Option<&str> {
-        let range: Range<usize> = span.into();
-        self.source.get(range)
+        let base = self.base.to_usize();
+        let start = span.start().to_usize() - base;
+        let end = span.end().to_usize() - base;
+        self.source.get(start..end)
     }
 
-    /// Gets the line index (0-indexed) for a byte position.
+    /// Converts a file-local byte position to a global span of length 1.
     #[inline]
-    fn line_index(&self, pos: BytePos) -> Option<usize> {
-        match self.line_starts.binary_search(&pos) {
-            Ok(idx) => Some(idx),
-            Err(idx) => match idx {
-                0 => None,
-                _ => Some(idx - 1),
-            },
-        }
+    pub fn single(&self, pos: impl Into<BytePos>) -> Span {
+        let base = self.base.to_u32();
+        let pos = pos.into() + base;
+        Span::single(pos)
     }
 
-    /// Converts a byte position to a line and column.
+    /// Creates a global [`Span`] from file-local byte offsets.
     ///
-    /// Returns None if the position is out of bounds.
+    /// This is a convenience method for constructing spans when you know the
+    /// file-local start and end positions (e.g., in tests or when integrating
+    /// with code that produces file-local offsets).
+    ///
+    /// Returns `None` if `local_start > local_end`.
+    #[inline]
+    pub fn span(&self, start: impl Into<BytePos>, end: impl Into<BytePos>) -> Option<Span> {
+        let base = self.base.to_u32();
+        let start = start.into() + base;
+        let end = end.into() + base;
+        Span::new(start, end)
+    }
+
+    /// Converts a global byte position to a line and column.
+    ///
+    /// Returns `None` if the position is outside this file's address range.
     pub fn line_col(&self, pos: BytePos) -> Option<LineCol> {
+        let pos = BytePos(pos - self.base);
         if pos.to_usize() > self.source.len() {
             return None;
         }
@@ -170,14 +179,14 @@ impl SourceFile {
         })
     }
 
-    /// Gets a Location containing line/column info and line text for a span.
+    /// Gets a Location containing line/column info and line text for a global span.
     ///
-    /// Returns None if the span is out of bounds.
+    /// Returns `None` if the span is outside this file's address range.
     pub fn location(&self, span: Span) -> Option<Location<'_>> {
         let line_col = self.line_col(span.start())?;
         let line_index = line_col.line as usize - 1;
         let end_line_index = self
-            .line_index(span.end())
+            .line_index(BytePos(span.end() - self.base))
             .unwrap_or(self.line_starts.len() - 1);
         let start = self.line_starts.get(line_index)?.to_usize();
         let end = self
@@ -191,9 +200,16 @@ impl SourceFile {
             line_text,
         })
     }
+
+    #[inline]
+    fn line_index(&self, pos: BytePos) -> Option<usize> {
+        self.line_starts
+            .partition_point(|&start| start <= pos)
+            .checked_sub(1)
+    }
 }
 
-/// Computes byte positions where each line starts.
+/// Computes file-local byte positions where each line starts.
 fn compute_line_starts(source: &str) -> Vec<BytePos> {
     let estimated_lines = source.len() / 80 + 1;
     let mut starts = Vec::with_capacity(estimated_lines);

--- a/crates/jcc_codemap/src/lib.rs
+++ b/crates/jcc_codemap/src/lib.rs
@@ -15,9 +15,17 @@
 //!
 //! # Core Concepts
 //!
+//! ## Global Address Space
+//!
+//! All source files share a single virtual u32 address space. Each file is allocated a
+//! unique, non-overlapping range. A [`Span`] therefore identifies both the file and the
+//! byte range within it.
+//!
+//! **Limit**: the total size of all source files must not exceed 4 GiB ([`u32::MAX`] bytes).
+//!
 //! ## Spans
 //!
-//! A [`Span`] represents a contiguous region in a source file using byte positions.
+//! A [`Span`] represents a contiguous region in the global address space using byte positions.
 //! Spans are half-open intervals: `[start, end)`.
 //!
 //! ## Files
@@ -43,25 +51,23 @@
 
 pub mod byte;
 pub mod file;
+pub mod simple;
 pub mod span;
 
+#[cfg(test)]
+pub mod testutil;
+
+#[cfg(feature = "color")]
 pub mod color;
 
 #[cfg(feature = "color")]
 use crate::color::ColorConfig;
-use crate::{
-    file::{FileId, SourceFile},
-    span::Span,
-};
+use crate::{byte::BytePos, file::SourceFile, span::Span};
 
 #[cfg(feature = "color")]
 use termcolor::WriteColor;
 
-use std::{
-    collections::HashMap,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, io::Write};
 
 /// A line and column position in a source file.
 ///
@@ -90,103 +96,38 @@ pub struct Location<'a> {
     pub line_text: &'a str,
 }
 
-/// A collection of source files.
+/// A collection of source files, addressable by global byte position.
 ///
-/// This is the main interface for managing multiple source files
-/// and looking up location information for spans.
+/// This is the main interface for managing multiple source files and looking up
+/// location information for spans.
+///
+/// # Invariant for custom implementations
+///
+/// Every [`SourceFile`] returned by an implementation MUST have a unique,
+/// non-overlapping range `[file.base(), file.base() + file.source().len())` in
+/// the global address space. Violating this invariant produces incorrect diagnostic
+/// output. See [`SimpleFiles`] for a correct reference implementation.
 pub trait Files {
-    /// Gets a source file by its ID.
+    /// Returns the source file whose global address range contains `pos`.
     ///
-    /// Returns None if the file ID is invalid.
-    fn get(&self, file_id: FileId) -> Option<&SourceFile>;
+    /// Returns `None` if no file contains the given position (e.g., the position
+    /// falls in a sentinel gap or beyond all loaded files).
+    fn file_for_pos(&self, pos: BytePos) -> Option<&SourceFile>;
 
-    /// Gets the name of a file.
+    /// Gets the source text slice for a global span.
     ///
-    /// Returns None if the file ID is invalid.
-    fn name(&self, file_id: FileId) -> Option<&Path>;
+    /// Returns `None` if no file contains the span's start position or the span
+    /// is out of bounds within that file.
+    fn slice(&self, span: Span) -> Option<&str> {
+        self.file_for_pos(span.start())?.slice(span)
+    }
 
-    /// Gets the source text slice for a span in a specific file.
+    /// Gets a location for a global span.
     ///
-    /// Returns None if the file or span is invalid.
-    fn source(&self, file_id: FileId, span: Span) -> Option<&str>;
-
-    /// Gets a location for a span in a specific file.
-    ///
-    /// Returns None if the file or span is invalid.
-    fn location(&self, file_id: FileId, span: Span) -> Option<Location<'_>>;
-}
-
-/// A simple in-memory collection of source files.
-///
-/// This is the default implementation that stores all source files
-/// in memory. For more advanced use cases (e.g., lazy loading,
-/// virtual files, or integration with an IDE), implement the Files trait.
-#[derive(Debug, Default, Clone)]
-pub struct SimpleFiles {
-    /// The list of source files.
-    files: Vec<SourceFile>,
-}
-
-impl SimpleFiles {
-    /// Creates a new empty file collection.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the number of files.
-    pub fn len(&self) -> usize {
-        self.files.len()
-    }
-
-    /// Returns true if there are no files.
-    pub fn is_empty(&self) -> bool {
-        self.files.is_empty()
-    }
-
-    /// Adds a file from source text with the given name.
-    pub fn add(&mut self, name: impl Into<PathBuf>, source: String) -> FileId {
-        let id = FileId::new(u32::try_from(self.files.len()).unwrap_or(u32::MAX));
-        let file = SourceFile::from_source(id, name, source);
-        self.files.push(file);
-        id
-    }
-
-    /// Adds a file from a path by reading it.
-    ///
-    /// # Errors
-    ///
-    /// If reading the file fails, an error is returned.
-    pub fn add_file(&mut self, path: impl AsRef<Path>) -> std::io::Result<FileId> {
-        let id = FileId::new(u32::try_from(self.files.len()).unwrap_or(u32::MAX));
-        let file = SourceFile::new(id, path)?;
-        self.files.push(file);
-        Ok(id)
-    }
-
-    /// Returns an iterator over all files.
-    pub fn iter(&self) -> impl Iterator<Item = (FileId, &SourceFile)> {
-        self.files
-            .iter()
-            .enumerate()
-            .map(|(i, f)| (FileId::new(u32::try_from(i).unwrap_or(u32::MAX)), f))
-    }
-}
-
-impl Files for SimpleFiles {
-    fn get(&self, file: FileId) -> Option<&SourceFile> {
-        self.files.get(file.as_usize())
-    }
-
-    fn name(&self, file: FileId) -> Option<&Path> {
-        self.get(file).map(SourceFile::name)
-    }
-
-    fn source(&self, file: FileId, span: Span) -> Option<&str> {
-        self.get(file)?.slice(span)
-    }
-
-    fn location(&self, file: FileId, span: Span) -> Option<Location<'_>> {
-        self.get(file)?.location(span)
+    /// Returns `None` if no file contains the span's start position or the span
+    /// is out of bounds within that file.
+    fn location(&self, span: Span) -> Option<Location<'_>> {
+        self.file_for_pos(span.start())?.location(span)
     }
 }
 
@@ -226,13 +167,12 @@ pub enum LabelStyle {
 /// A label attached to a specific span in the source code.
 ///
 /// Labels provide context about why a particular piece of code
-/// is relevant to the diagnostic.
+/// is relevant to the diagnostic. The span must be a global span
+/// (allocated through a [`Files`] database).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Label {
-    /// The span this label points to.
+    /// The global span this label points to.
     pub span: Span,
-    /// The file containing this label.
-    pub file: FileId,
     /// The style of this label (primary or secondary).
     pub style: LabelStyle,
     /// An optional message describing what's wrong with this span.
@@ -241,9 +181,8 @@ pub struct Label {
 
 impl Label {
     /// Creates a new primary label at the given span.
-    pub fn primary(file: FileId, span: Span) -> Self {
+    pub fn primary(span: Span) -> Self {
         Self {
-            file,
             span,
             message: None,
             style: LabelStyle::Primary,
@@ -251,9 +190,8 @@ impl Label {
     }
 
     /// Creates a new secondary label at the given span.
-    pub fn secondary(file: FileId, span: Span) -> Self {
+    pub fn secondary(span: Span) -> Self {
         Self {
-            file,
             span,
             message: None,
             style: LabelStyle::Secondary,
@@ -273,22 +211,23 @@ impl Label {
 /// It is independent of formatting concerns and is intended to be converted into a
 /// [`Diagnostic`] for display to the user.
 ///
+/// The span is a global span whose position implicitly encodes which file the
+/// issue originates from.
+///
 /// The generic parameter `K` represents the kind of issue.
 #[derive(Clone)]
 pub struct Issue<K> {
     /// The kind of the issue.
     pub kind: K,
-    /// The span associated with this issue.
+    /// The global span associated with this issue.
     pub span: Span,
-    /// The source file in which this issue occurred.
-    pub file: FileId,
 }
 
 impl<K> Issue<K> {
-    /// Creates a new issue of the given kind.
+    /// Creates a new issue of the given kind at the given global span.
     #[inline]
-    pub fn new(kind: K, file: FileId, span: Span) -> Self {
-        Self { kind, span, file }
+    pub fn new(kind: K, span: Span) -> Self {
+        Self { kind, span }
     }
 }
 
@@ -298,18 +237,14 @@ impl<K> Issue<K> {
 /// into structured diagnostic output.
 pub trait IntoDiagnostic {
     /// Converts this issue kind into a fully rendered [`Diagnostic`],
-    /// using the provided source location context.
-    fn into_diagnostic(self, file: FileId, span: Span) -> Diagnostic;
+    /// using the provided global source span.
+    fn into_diagnostic(self, span: Span) -> Diagnostic;
 }
 
 impl<K: IntoDiagnostic> From<Issue<K>> for Diagnostic {
     /// Converts a semantic compiler [`Issue`] into a user-facing [`Diagnostic`].
-    ///
-    /// This bridges the gap between compiler analysis and diagnostic rendering.
-    /// The issue's kind is responsible for defining how it is displayed, while
-    /// this implementation supplies the associated source location context.
     fn from(issue: Issue<K>) -> Self {
-        issue.kind.into_diagnostic(issue.file, issue.span)
+        issue.kind.into_diagnostic(issue.span)
     }
 }
 
@@ -508,12 +443,13 @@ fn emit_diagnostic<F: Files>(
         write!(writer, "[{code}]")?;
     }
     writeln!(writer, ": {}", diagnostic.message)?;
-    for (file, labels) in group_labels(&diagnostic.labels) {
-        let name = files
-            .name(file)
-            .map_or_else(|| format!("{file:?}"), |p| p.display().to_string());
+    for (file, labels) in group_labels(files, &diagnostic.labels) {
+        let name = labels
+            .first()
+            .and_then(|l| files.file_for_pos(l.span.start()))
+            .map_or_else(|| format!("{file:?}"), |f| f.name().display().to_string());
         for label in labels {
-            if let Some(location) = files.location(file, label.span) {
+            if let Some(location) = files.location(label.span) {
                 emit_label(writer, &name, &location, label)?;
             }
         }
@@ -524,13 +460,18 @@ fn emit_diagnostic<F: Files>(
     Ok(())
 }
 
-/// Groups labels of a diagnostic.
-fn group_labels(labels: &[Label]) -> HashMap<FileId, Vec<&Label>> {
-    let mut file_labels: HashMap<FileId, Vec<&Label>> = HashMap::new();
+/// Groups labels by file (keyed by a pointer to the source file) and sorts each group by span start.
+pub fn group_labels<'a, F: Files>(
+    files: &F,
+    labels: &'a [Label],
+) -> HashMap<*const SourceFile, Vec<&'a Label>> {
+    let mut file_labels: HashMap<*const SourceFile, Vec<&'a Label>> = HashMap::new();
     for label in labels {
-        file_labels.entry(label.file).or_default().push(label);
+        if let Some(key) = files.file_for_pos(label.span.start()) {
+            file_labels.entry(key).or_default().push(label);
+        }
     }
-    for labels in &mut file_labels.values_mut() {
+    for labels in file_labels.values_mut() {
         labels.sort_by_key(|l| l.span.start());
     }
     file_labels
@@ -621,34 +562,7 @@ fn emit_label(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-
-    struct TestFiles {
-        files: SimpleFiles,
-        test_file: FileId,
-        example_file: FileId,
-        unicode_file: FileId,
-    }
-
-    fn create_test_files() -> TestFiles {
-        let mut files = SimpleFiles::new();
-        let test_file = files.add("test.rs", "let x = 5;".to_string());
-        let unicode_file = files.add("unicode.rs", "let café = \"☕\";".to_string());
-        let example_file = files.add(
-            "example.rs",
-            r#"fn main() {
-    let x = 5;
-    let y = x + "hello";
-    println!("{}", y);
-}"#
-            .to_string(),
-        );
-        TestFiles {
-            files,
-            test_file,
-            example_file,
-            unicode_file,
-        }
-    }
+    use crate::testutil::create_test_files;
 
     #[test]
     fn test_severity_ordering() {
@@ -680,7 +594,7 @@ mod tests {
         let diagnostic = Diagnostic::help()
             .with_message("this is a help message")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("consider changing this"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -701,8 +615,7 @@ help: this is a help message
         let diagnostic = Diagnostic::note()
             .with_message("this is a note message")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
-                    .with_message("just so you know"),
+                Label::primary(files.span(files.test_file, 4, 5)).with_message("just so you know"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
         let expected = "\
@@ -722,7 +635,7 @@ note: this is a note message
         let diagnostic = Diagnostic::error()
             .with_message("variable not found")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("not found in this scope"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -743,7 +656,7 @@ error: variable not found
         let diagnostic = Diagnostic::warning()
             .with_message("unused variable: `x`")
             .with_label(
-                Label::primary(files.example_file, Span::new(20u32, 21u32).unwrap())
+                Label::primary(files.span(files.example_file, 20, 21))
                     .with_message("help: if this is intentional, prefix with underscore: `_x`"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -765,7 +678,7 @@ warning: unused variable: `x`
             .with_code("E0425")
             .with_message("cannot find value `z` in this scope")
             .with_label(
-                Label::primary(files.test_file, Span::new(4u32, 5u32).unwrap())
+                Label::primary(files.span(files.test_file, 4, 5))
                     .with_message("not found in this scope"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -785,10 +698,7 @@ error[E0425]: cannot find value `z` in this scope
         let files = create_test_files();
         let diagnostic = Diagnostic::error()
             .with_message("cannot borrow as mutable")
-            .with_label(Label::primary(
-                files.test_file,
-                Span::new(0u32, 3u32).unwrap(),
-            ))
+            .with_label(Label::primary(files.span(files.test_file, 0, 3)))
             .with_notes(vec![
                 "consider changing this to be mutable: `mut x`",
                 "see documentation on borrowing for more information",
@@ -828,7 +738,7 @@ warning: potential issue detected
         let diagnostic = Diagnostic::error()
             .with_message("expected expression")
             .with_label(
-                Label::primary(files.test_file, Span::new(3u32, 3u32).unwrap())
+                Label::primary(files.span(files.test_file, 3, 3))
                     .with_message("expected expression here"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -846,13 +756,9 @@ error: expected expression
     #[test]
     fn test_label_without_message() {
         let files = create_test_files();
-        let diagnostic =
-            Diagnostic::error()
-                .with_message("syntax error")
-                .with_label(Label::primary(
-                    files.test_file,
-                    Span::new(4u32, 5u32).unwrap(),
-                ));
+        let diagnostic = Diagnostic::error()
+            .with_message("syntax error")
+            .with_label(Label::primary(files.span(files.test_file, 4, 5)));
         let output = diagnostic.emit_to_string(&files.files).unwrap();
         let expected = "\
 error: syntax error
@@ -870,7 +776,7 @@ error: syntax error
         let diagnostic = Diagnostic::error()
             .with_message("invalid character in identifier")
             .with_label(
-                Label::primary(files.unicode_file, Span::new(4u32, 8u32).unwrap())
+                Label::primary(files.span(files.unicode_file, 4, 8))
                     .with_message("unexpected character"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -891,7 +797,7 @@ error: invalid character in identifier
         let diagnostic = Diagnostic::error()
             .with_message("missing semicolon")
             .with_label(
-                Label::primary(files.test_file, Span::new(9u32, 10u32).unwrap())
+                Label::primary(files.span(files.test_file, 9, 10))
                     .with_message("expected `;` here"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -912,7 +818,7 @@ error: missing semicolon
         let diagnostic = Diagnostic::error()
             .with_message("unclosed delimiter")
             .with_label(
-                Label::primary(files.example_file, Span::new(0u32, 74u32).unwrap())
+                Label::primary(files.span(files.example_file, 0, 74))
                     .with_message("function body not closed"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -940,8 +846,7 @@ error: unclosed delimiter
         let diagnostic = Diagnostic::note()
             .with_message("related information")
             .with_label(
-                Label::secondary(files.test_file, Span::new(4u32, 5u32).unwrap())
-                    .with_message("defined here"),
+                Label::secondary(files.span(files.test_file, 4, 5)).with_message("defined here"),
             );
         let output = diagnostic.emit_to_string(&files.files).unwrap();
         let expected = "\
@@ -961,9 +866,9 @@ note: related information
         let diagnostic = Diagnostic::error()
             .with_message("mismatched types")
             .with_labels(vec![
-                Label::primary(files.example_file, Span::new(37u32, 38u32).unwrap())
+                Label::primary(files.span(files.example_file, 37, 38))
                     .with_message("expected integer"),
-                Label::secondary(files.example_file, Span::new(43u32, 50u32).unwrap())
+                Label::secondary(files.span(files.example_file, 43, 50))
                     .with_message("this is a string"),
             ]);
         let output = diagnostic.emit_to_string(&files.files).unwrap();
@@ -990,9 +895,9 @@ error: mismatched types
             .with_code("E0308")
             .with_message("mismatched types")
             .with_labels(vec![
-                Label::primary(files.example_file, Span::new(37u32, 38u32).unwrap())
+                Label::primary(files.span(files.example_file, 37, 38))
                     .with_message("expected `i32`, found `&str`"),
-                Label::secondary(files.example_file, Span::new(20u32, 21u32).unwrap())
+                Label::secondary(files.span(files.example_file, 20, 21))
                     .with_message("`x` is defined here as `i32`"),
             ])
             .with_note("expected type `i32`")

--- a/crates/jcc_codemap/src/simple.rs
+++ b/crates/jcc_codemap/src/simple.rs
@@ -1,0 +1,119 @@
+//! A simple in-memory [`crate::Files`] implementation.
+//!
+//! [`SimpleFiles`] maintains a flat list of source files, assigning each a
+//! non-overlapping range in a global byte-address space. A one-byte sentinel
+//! gap is inserted between files so that a [`crate::span::Span`] can never
+//! accidentally straddle a file boundary. Lookup by position is O(log n) via
+//! binary search.
+//!
+//! This is the default implementation. For more advanced use cases such as
+//! lazy loading, virtual files, or IDE integration, implement the [`crate::Files`]
+//! trait directly.
+
+use crate::{byte::BytePos, file::SourceFile, Files};
+
+use std::path::{Path, PathBuf};
+
+/// An opaque identifier for a source file.
+///
+/// This is used to reference files in a Files database.
+/// File IDs are stable and can be stored in your AST or IR.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FileId(u32);
+
+impl FileId {
+    /// Returns the underlying usize value.
+    #[inline]
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// A simple in-memory collection of source files.
+///
+/// Files are allocated sequential, non-overlapping ranges in the global address
+/// space, with a one-byte sentinel gap between each file so that spans cannot
+/// accidentally straddle file boundaries.
+///
+/// This is the default implementation. For more advanced use cases (e.g., lazy
+/// loading, virtual files, or integration with an IDE), implement the [`Files`] trait.
+#[derive(Debug, Default, Clone)]
+pub struct SimpleFiles {
+    /// The next available global base address.
+    next_base: BytePos,
+    /// The list of source files, sorted by ascending base offset.
+    files: Vec<SourceFile>,
+}
+
+impl Files for SimpleFiles {
+    fn file_for_pos(&self, pos: BytePos) -> Option<&SourceFile> {
+        let idx = self.files.partition_point(|f| f.base() <= pos);
+        let file = self.files.get(idx.checked_sub(1)?)?;
+        // Verify pos is not in the sentinel gap or past end of file.
+        if pos < file.end() {
+            Some(file)
+        } else {
+            None
+        }
+    }
+}
+
+impl SimpleFiles {
+    /// Creates a new empty file collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of files.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Returns true if there are no files.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Adds a file from source text with the given name.
+    pub fn add(&mut self, name: impl Into<PathBuf>, source: String) -> FileId {
+        let id = FileId(u32::try_from(self.files.len()).unwrap_or(u32::MAX));
+        let base = self.next_base;
+        let len = u32::try_from(source.len()).unwrap_or(u32::MAX);
+        self.next_base = BytePos::from(base.to_u32().saturating_add(len).saturating_add(1));
+        self.files.push(SourceFile::from_source(base, name, source));
+        id
+    }
+
+    /// Adds a file from a path by reading it.
+    ///
+    /// # Errors
+    ///
+    /// If reading the file fails, an error is returned.
+    pub fn add_file(&mut self, path: impl AsRef<Path>) -> std::io::Result<FileId> {
+        let id = FileId(u32::try_from(self.files.len()).unwrap_or(u32::MAX));
+        let base = self.next_base;
+        let file = SourceFile::new(base, path)?;
+        let len = u32::try_from(file.source().len()).unwrap_or(u32::MAX);
+        self.next_base = BytePos::from(base.to_u32().saturating_add(len).saturating_add(1));
+        self.files.push(file);
+        Ok(id)
+    }
+
+    /// Returns the name of the file with the given ID, or `None` if the ID is invalid.
+    pub fn name(&self, file_id: FileId) -> Option<&Path> {
+        self.get(file_id).map(SourceFile::name)
+    }
+
+    /// Returns the source file with the given ID, or `None` if the ID is invalid.
+    pub fn get(&self, file_id: FileId) -> Option<&SourceFile> {
+        self.files.get(file_id.as_usize())
+    }
+
+    /// Returns an iterator over all files.
+    pub fn iter(&self) -> impl Iterator<Item = (FileId, &SourceFile)> {
+        self.files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (FileId(u32::try_from(i).unwrap_or(u32::MAX)), f))
+    }
+}

--- a/crates/jcc_codemap/src/testutil.rs
+++ b/crates/jcc_codemap/src/testutil.rs
@@ -1,0 +1,47 @@
+//! Test utilities for building source file fixtures.
+
+use crate::{
+    simple::{FileId, SimpleFiles},
+    span::Span,
+};
+
+/// A collection of pre-loaded source files for use in tests.
+pub struct TestFiles {
+    /// The underlying file store.
+    pub files: SimpleFiles,
+    /// A simple single-line source file (`test.rs`).
+    pub test_file: FileId,
+    /// A multi-line source file (`example.rs`).
+    pub example_file: FileId,
+    /// A source file containing non-ASCII characters (`unicode.rs`).
+    pub unicode_file: FileId,
+}
+
+impl TestFiles {
+    /// Returns a [`Span`] within `id` covering bytes `start..end`.
+    pub fn span(&self, id: FileId, start: u32, end: u32) -> Span {
+        self.files.get(id).unwrap().span(start, end).unwrap()
+    }
+}
+
+/// Creates a [`TestFiles`] instance with three pre-populated source files.
+pub fn create_test_files() -> TestFiles {
+    let mut files = SimpleFiles::new();
+    let test_file = files.add("test.rs", "let x = 5;".to_string());
+    let unicode_file = files.add("unicode.rs", "let café = \"☕\";".to_string());
+    let example_file = files.add(
+        "example.rs",
+        r#"fn main() {
+    let x = 5;
+    let y = x + "hello";
+    println!("{}", y);
+}"#
+        .to_string(),
+    );
+    TestFiles {
+        files,
+        test_file,
+        example_file,
+        unicode_file,
+    }
+}


### PR DESCRIPTION
## Eliminate `FileId` from `Issue`, `Label`, and `IntoDiagnostic`

### Motivation

Previously every `Issue<K>` and `Label` had to carry a `FileId` alongside its `Span` so the diagnostic renderer could look up which file the span belonged to. This forced every error-reporting site to thread a file ID through, and made `IntoDiagnostic` take an extra `file: FileId` parameter that was only used to construct a label.

### Change

Each `SourceFile` now holds a **global base offset** in a shared virtual address space managed by `SimpleFiles`. Files are allocated contiguous, non-overlapping ranges (`[base, base + len)`) with a 1-byte sentinel gap between them. A `Span`'s start position alone is enough to identify the file.

`SimpleFiles` implements `file_for_pos(BytePos) -> Option<&SourceFile>` using binary search over file bases, and the `Files` trait provides default implementations of `source(Span)` and `location(Span)` on top of it.
